### PR TITLE
Made images over the fixed page size resize to the margined value

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -409,6 +409,19 @@ class ShowOff < Sinatra::Application
         w, h     = get_image_size(img_path)
         src      = %(#{replacement_prefix}/#{$1}")
         if w && h
+	  if w > h
+	    # Landscape
+	    if w > 960
+	      w = 960
+	      h = "auto"
+	    end
+	  else
+	    # Portrait
+	    if h > 704
+	      h = 704
+	      w = "auto"
+	    end	    
+	  end
           src << %( width="#{w}" height="#{h}")
         end
         src


### PR DESCRIPTION
I was using this software last weekend, and had to include the below hack to make my images (sized at 1200xsomething) fit on the page.

It could probably come out much cleaner if one is more competent with ruby (I've never used it before!) but this was a simple hack to make larger images fit right.

Happy to adjust if required.
