### PR TITLE
Adds an endpoint to call out to a local editor

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -27,6 +27,13 @@ div.zoomed {
     float: left;
     margin: 0.5em 0 0 0.5em;
   }
+    #slideSource a {
+      color: #fff;
+      text-decoration: none;
+    }
+    #slideSource a:hover {
+      background-color: #555;
+    }
   #links {
     position: relative;
     top: 0.7em;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -118,10 +118,18 @@ function reportIssue() {
   window.open(link);
 }
 
+// open browser to remote edit URL
 function editSlide() {
   var slide = $("span#slideFile").text().replace(/\/\d+$/, '');
   var link  = editUrl + slide + ".md";
   window.open(link);
+}
+
+// call the edit endpoint to open up a local file editor
+function openEditor() {
+  var slide = $("span#slideFile").text().replace(/\/\d+$/, '');
+  var link  = '/edit/' + slide + ".md";
+  $.get(link);
 }
 
 function toggleSlave() {

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -31,7 +31,12 @@
 <div id="main">
   <div id="topbar">
     <div id="slideSource">
-      Source: <span id="slideFile"></span>
+      Source:
+      <% if @request.host == 'localhost' %>
+        <a href="javascript:openEditor();"><span id="slideFile"></span></a>
+      <% else %>
+        <span id="slideFile">
+      <% end %>
     </div>
     <span id="links">
       <span class="desktop">


### PR DESCRIPTION
1. Run showoff locally
2. browse to http://localhost:9090/presenter
3. Navigate to a slide
4. Click the slide name in the upper left
5. Showoff opens the OS configured markdown editor

Notes:
- OS independent.
  - Uses `open` on OS X
  - Uses `xdg-open` on Linux
  - Uses `start` on Windows
- Only allows edit when running locally and connecting to localhost
- Will only edit an existing file

Fixes #224
