### PR TITLE
Ticket/229/maintain next zoom

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -194,7 +194,7 @@ function openNext()
   if (mode.next) {
     try {
       if(nextWindow == null || typeof(nextWindow) == 'undefined' || nextWindow.closed){
-          nextWindow = window.open('/?track=false&feedback=false&next=true#' + nextSlideNum(true),'','width=300,height=200');
+          nextWindow = window.open('/?track=false&feedback=false&next=true#' + nextSlideNum(true),'','width=320,height=300');
       }
       else if(nextWindow.location.hash != '#' + nextSlideNum(true)) {
         // maybe we need to reset content?

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -62,7 +62,11 @@ function setupPreso(load_slides, prefix) {
   if(query.track == 'false') mode.track = false;
 
   // make sure that the next view doesn't bugger things on the first load
-  if(query.next == 'true')   mode.next = true;
+  if(query.next == 'true') {
+    $('#preso').addClass('zoomed');
+    mode.next = true;
+    zoom();
+  }
 
   // Make sure the slides always look right.
   // Better would be dynamic calculations, but this is enough for now.
@@ -188,6 +192,28 @@ function initializePresentation(prefix) {
   });
 
 	$("#preso").trigger("showoff:loaded");
+}
+
+/* This looks like the zoom() function for the presenter preview, but it uses a different algorithm */
+function zoom()
+{
+  if(window.innerWidth <= 480) {
+    $(".zoomed").css("zoom", 0.32);
+  }
+  else {
+    var hSlide = parseFloat($("#preso").height());
+    var wSlide = parseFloat($("#preso").width());
+    var hBody  = parseFloat($("html").height());
+    var wBody  = parseFloat($("html").width());
+
+    newZoom = Math.min(hBody/hSlide, wBody/wSlide) - 0.04;
+
+    $(".zoomed").css("zoom", newZoom);
+    $(".zoomed").css("-ms-zoom", newZoom);
+    $(".zoomed").css("-webkit-zoom", newZoom);
+    $(".zoomed").css("-moz-transform", "scale("+newZoom+")");
+    $(".zoomed").css("-moz-transform-origin", "left top");
+  }
 }
 
 function centerSlides(slides) {


### PR DESCRIPTION
- This calculates and maintains proper zoom levels on the next window.
  This means that the window is now resizable.
- Turns out that it working was simply an accident in the first
  place--all windows at that size used the mobile view already, which
  was already zoomed.
- This uses a zoom() function similar to the one in the presenter
  preview, but it's a slightly different algorithm.

Fixes #229 
