### PR TITLE
Make incremental bullets work in presenter again

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -222,6 +222,11 @@ div.zoomed {
         margin: 0.5em 1em;
       }
 
+      #preview .content ul li.incremental.hidden {
+        display: block;
+        color: #ccc;
+      }
+
     #statusbar {
       height: 22px;
       line-height: 22px;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -155,6 +155,10 @@
 
 .bullets ul ul > li { font-size: 80%; }
 
+.content ul li.incremental.hidden {
+  display: none;
+}
+
 .commandline pre {
     font-size: 2em;
 }
@@ -199,8 +203,12 @@ h3 { font-size: 2em; }
 
 pre { margin: 1em 40px; padding: .25em; }
 
+#navigation.hidden,
+#stylepicker.hidden {
+  position:absolute; top:0; left:-9999px; width:1px; height:1px; overflow:hidden;
+}
+
 .notes, .handouts, .instructor, .solguide { display: none }
-.hidden { position:absolute; top:0; left:-9999px; width:1px; height:1px; overflow:hidden; }
 .buttonNav { display: none }
 .offscreen { position:absolute; top:0; left:-9999px; overflow:hidden; }
 #debugInfo { margin-left: 30px; }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -297,8 +297,9 @@ function setupSlideParamsCheck() {
 }
 
 function gotoSlide(slideNum, updatepv) {
-  slidenum = parseInt(slideNum);
-  if (!isNaN(slidenum)) {
+  newslide = parseInt(slideNum);
+  if (slidenum != newslide && !isNaN(newslide)) {
+    slidenum = newslide;
     showSlide(false, updatepv);
   }
 }
@@ -363,6 +364,10 @@ function showSlide(back_step, updatepv) {
 
 	var fileName = currentSlide.children().first().attr('ref');
   $('#slideFilename').text(fileName);
+
+  if (query.next) {
+    $(currentSlide).find('li').removeClass('hidden');
+  }
 
   // Update presenter view, if we spawned one
 	if (updatepv && 'presenterView' in window && ! mode.next) {
@@ -436,7 +441,7 @@ function determineIncremental()
 		incrCode = true
 	}
 	incrElem.each(function(s, elem) {
-		$(elem).css('visibility', 'hidden');
+		$(elem).addClass('incremental hidden');
 	})
 }
 
@@ -444,9 +449,9 @@ function showIncremental(incr)
 {
 		elem = incrElem.eq(incrCurr)
 		if (incrCode && elem.hasClass('command')) {
-			incrElem.eq(incrCurr).css('visibility', 'visible').jTypeWriter({duration:1.0})
+			incrElem.eq(incrCurr).removeClass('hidden').jTypeWriter({duration:1.0})
 		} else {
-			incrElem.eq(incrCurr).css('visibility', 'visible')
+			incrElem.eq(incrCurr).removeClass('hidden')
 		}
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -297,7 +297,7 @@ function setupSlideParamsCheck() {
 }
 
 function gotoSlide(slideNum, updatepv) {
-  newslide = parseInt(slideNum);
+  var newslide = parseInt(slideNum);
   if (slidenum != newslide && !isNaN(newslide)) {
     slidenum = newslide;
     showSlide(false, updatepv);
@@ -447,11 +447,11 @@ function determineIncremental()
 
 function showIncremental(incr)
 {
-		elem = incrElem.eq(incrCurr)
+		elem = incrElem.eq(incrCurr);
 		if (incrCode && elem.hasClass('command')) {
-			incrElem.eq(incrCurr).removeClass('hidden').jTypeWriter({duration:1.0})
+			incrElem.eq(incrCurr).removeClass('hidden').jTypeWriter({duration:1.0});
 		} else {
-			incrElem.eq(incrCurr).removeClass('hidden')
+			incrElem.eq(incrCurr).removeClass('hidden');
 		}
 }
 


### PR DESCRIPTION
- remote tracking was killing the incremental bullets. It would enable
  the next bullet, then immediately reload the slide :(
- Disables incremental bullets on the next view. Just show all bullets.
- In the presenter, don't hide invisible bullets, just dim them out.

Fixes #132
