### PR TITLE
Enable running tests with http://travis-ci.org/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ vendor
 
 ## PROJECT::SPECIFIC
 dist
+/stats
 
 ## IntelliJ IDEA
 *.ipr
 *.iml
 *.iws
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+
+before_install:
+  - git config --global user.name "TravisCI"
+  - git config --global user.email "noreply@example.com"
+  - sudo apt-get install wkhtmltopdf

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 
 group :development do
-  gem "mg"
   gem "turn"
   gem "rack-test"
   gem "pdf-inspector"
@@ -12,4 +11,8 @@ end
 group :optional do
   gem "rmagick"
   gem "pdfkit"
+end
+
+group :test do
+  gem 'rake'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+task default: :test
+
 desc "Build HTML documentation"
 task :doc do
   system("rdoc --main README.rdoc README.rdoc documentation/*.rdoc")


### PR DESCRIPTION
Tests are currently failing for me locally.  I think it is a good idea to enable testing i travis-ci.

This PR contains a few changes necessary to run the tests in travis-ci.

I have enabled tests in travis-ci for my fork here:  https://travis-ci.org/donv/showoff

The tests run in travis-ci have the same failures I have locally.
