### PR TITLE
Only center slide after images have loaded

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -226,9 +226,27 @@ function zoom()
 }
 
 function centerSlides(slides) {
-	slides.each(function(s, slide) {
-		centerSlide(slide)
-	})
+  slides.each(function(s, slide) {
+    waitForImagesThenCenter(slide);
+  })
+}
+
+function waitForImagesThenCenter(slide) {
+  function waitForContent(slide) {
+    var imagesLoaded = true;
+    $(slide).find("img").each(function(img) {
+      if(! img.complete) {
+        imagesLoaded = false;
+      }
+    });
+    if(imagesLoaded) {
+      centerSlide(slide);
+    }
+    else {
+      setTimeout(function() { waitForContent(slide) }, 100);
+    }
+  }
+  setTimeout(waitForContent, 0);
 }
 
 function centerSlide(slide) {


### PR DESCRIPTION
When slides contain images, the images often have not loaded when the page is centred. This results in images appearing partially off screen.
