### PR TITLE
Fix/included file syntax highlighting

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -405,11 +405,14 @@ class ShowOff < Sinatra::Application
 
       # Load and replace any file tags
       content.scan(/(~~~FILE:([^:]*):?(.*)?~~~)/).each do |match|
-        # get the file content and parse out html entities
-        file = HTMLEntities.new.encode(File.read(File.join(settings.pres_dir, '_files', match[1])))
-
-        # make a list of sh_highlight classes to include
+        # make a list of code highlighting classes to include
         css  = match[2].split.collect {|i| "language-#{i.downcase}" }.join(' ')
+
+        # get the file content and parse out html entities
+        name = match[1]
+        file = File.read(File.join(settings.pres_dir, '_files', name)) rescue "Nonexistent file: #{name}"
+        file = "Empty file: #{name}" if file.empty?
+        file = HTMLEntities.new.encode(file) rescue "HTML parsing of #{name} failed"
 
         result.gsub!(match[0], "<pre class=\"highlight\"><code class=\"#{css}\">#{file}</code></pre>")
       end
@@ -741,6 +744,10 @@ class ShowOff < Sinatra::Application
       html.css('pre').each do |pre|
         pre.css('code').each do |code|
           out = code.text
+
+          # Skip this if we've got an empty code block
+          next if out.empty?
+
           lines = out.split("\n")
           if lines.first.strip[0, 3] == '@@@'
             lang = lines.shift.gsub('@@@', '').strip

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -409,9 +409,9 @@ class ShowOff < Sinatra::Application
         file = HTMLEntities.new.encode(File.read(File.join(settings.pres_dir, '_files', match[1])))
 
         # make a list of sh_highlight classes to include
-        css  = match[2].split.collect {|i| "sh_#{i.downcase}" }.join(' ')
+        css  = match[2].split.collect {|i| "language-#{i.downcase}" }.join(' ')
 
-        result.gsub!(match[0], "<pre class=\"#{css}\"><code>#{file}</code></pre>")
+        result.gsub!(match[0], "<pre class=\"highlight\"><code class=\"#{css}\">#{file}</code></pre>")
       end
 
       result

--- a/test/fixtures/complete/_files/test.rb
+++ b/test/fixtures/complete/_files/test.rb
@@ -1,0 +1,4 @@
+#! /usr/bin/env ruby
+
+puts 'hello world'
+

--- a/test/fixtures/complete/fourth/slide.md
+++ b/test/fixtures/complete/fourth/slide.md
@@ -7,3 +7,23 @@
 * first point
 * second point
 * third point
+
+<!SLIDE>
+# Code file
+
+~~~FILE:test.rb:Ruby~~~
+
+<!SLIDE>
+# Empty code file
+
+This code block should be empty
+
+~~~FILE:test2.rb:Ruby~~~
+
+<!SLIDE>
+# Missing code file
+
+This code file doesn't exist
+
+~~~FILE:missing.rb:Ruby~~~
+


### PR DESCRIPTION
- Corrects syntax highlighting on included files.
- Rescues failures when included files don't exist or are empty.

Fixes #217
