### PR TITLE
moved reload on resize to only work on preview window

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -13,9 +13,6 @@ $(document).ready(function(){
   // to enabling this. It does not by default, so this is likely a no-op.
   openSlave();
 
-  // the presenter window doesn't need the reload on resize bit
-  $(window).unbind('resize');
-
   // side menu accordian crap
 	$("#preso").bind("showoff:loaded", function (event) {
 		$(".menu > ul ul").hide()

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -65,11 +65,10 @@ function setupPreso(load_slides, prefix) {
     $('#preso').addClass('zoomed');
     mode.next = true;
     zoom();
+    $(window).resize(function() {
+      location.reload();
+    });
   }
-
-  // Make sure the slides always look right.
-  // Better would be dynamic calculations, but this is enough for now.
-  $(window).resize(function(){location.reload();});
 
   $("#feedbackWrapper").hover(
     function() {


### PR DESCRIPTION
Provides a smoother experience for audience (doesn't reload every time the window is resized) while preserving functionality for presenter preview window
