### PR TITLE
Correct the widget spacing in the sidebar

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -109,6 +109,7 @@ div.zoomed {
       margin-bottom: 0.25em;
       padding-left: 0.5em;
       height: 2.15em;
+      min-height: 2.15em;
       line-height: 2.15em;
       vertical-align: middle;
     }
@@ -129,6 +130,7 @@ div.zoomed {
 
     #sidebar #feedbackPace {
       height: 40px;
+      min-height: 40px;
       position: relative;
       background: transparent url(pace.png) no-repeat center bottom;
     }


### PR DESCRIPTION
This prevents the timer and pace widgets from getting squashed as the
accordian menu expands.
