### PR TITLE
Worked around print issue by using static sizes

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -453,6 +453,18 @@ is your preference. An example of adding some styling is here.
 Note that the example above uses CSS3 styling with <tt>::after</tt> and the <tt>content</tt>
 -attribute to add an image to the slides.
 
+If you would like to use CSS to change the size of your slides from the default of
+1024x768, you'll want to use rules such as:
+
+    #preso,
+    .slide,
+    .content img {
+        width: 1280px !important;
+        height: 800px !important;
+        max-width: 1280px !important;
+        max-height: 800px !important;
+    }
+
 = Templates
 
 Templates can come handy if you need more than what you can achieve

--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -457,12 +457,9 @@ If you would like to use CSS to change the size of your slides from the default 
 1024x768, you'll want to use rules such as:
 
     #preso,
-    .slide,
-    .content img {
+    .slide {
         width: 1280px !important;
         height: 800px !important;
-        max-width: 1280px !important;
-        max-height: 800px !important;
     }
 
 = Templates

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -89,6 +89,11 @@
     transform: translateY(-50%);
   }
 
+  /* prevent large images from getting too out of hand */
+  .content img {
+    max-width: 100%;
+    max-height: 100%;
+  }
 }
 
 .slide .center {
@@ -111,12 +116,6 @@
 .content > form > blockquote {
     font-size: 250%;
     margin: 2em;
-}
-
-/* prevent large images from getting too out of hand */
-.content img {
-  max-width: 768px;
-  max-height: 1024px;
 }
 
 .center img {
@@ -887,6 +886,12 @@ body#stats {
       margin-left:auto;
       margin-right:auto;
       overflow:hidden;
+  }
+
+  /* prevent large images from running off the page */
+  .content img {
+    max-width: 7in;
+    max-height: 9.5in;
   }
 
   #footer {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -88,7 +88,7 @@
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
   }
-  
+
 }
 
 .slide .center {
@@ -115,8 +115,8 @@
 
 /* prevent large images from getting too out of hand */
 .content img {
-  max-width: 100%;
-  max-height: 100%;
+  max-width: 768px;
+  max-height: 1024px;
 }
 
 .center img {


### PR DESCRIPTION
Apparently wkhtmltopdf cannot print using a percentage-based size, so it
helpfully just discards images. This adds a hard coded pixel size back
in. It also includes a note in the docs about how to override it and
change the image size.
