### PR TITLE
Only set target if the link is external.

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -458,9 +458,9 @@ class ShowOff < Sinatra::Application
         end
       end
 
-      # Now add a target so we open all links from notes in a new window
+      # Now add a target so we open all external links from notes in a new window
       doc.css('a').each do |link|
-        link.set_attribute('target', '_blank')
+        link.set_attribute('target', '_blank') unless link['href'].start_with? '#'
       end
 
       doc.to_html


### PR DESCRIPTION
Prior to this, internal links in the notes would open a new window/tab
instead of switching to that slide. This corrects it.
