### PR TITLE
Show number of responses in quiz results

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1158,16 +1158,21 @@ class ShowOff < Sinatra::Application
 
     @@forms[id].each_with_object({}) do |(ip,form), sum|
       form.each do |key, val|
-        sum[key]      ||= {}
+        # initialize the object with an empty response if needed
+        sum[key] ||= { 'count' => 0, 'responses' => {} }
 
+        # increment the number of unique responses we've seen
+        sum[key]['count'] += 1
+
+        responses = sum[key]['responses']
         if val.class == Array
           val.each do |item|
-            sum[key][item] ||= 0
-            sum[key][item]  += 1
+            responses[item] ||= 0
+            responses[item]  += 1
           end
         else
-          sum[key][val] ||= 0
-          sum[key][val]  += 1
+          responses[val] ||= 0
+          responses[val]  += 1
         end
       end
     end.to_json

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -349,6 +349,17 @@ div.zoomed {
     list-style-type: disc;
   }
 
+  #notes div.rendered.form span.count {
+    display: inline;
+    float: right;
+    font-size: 2.5em;
+    background-color: #ddd;
+    padding: 0.1em 0.1em 0 0.1em;
+    border: 1px solid #333;
+    border-radius: 0 0.15em 0 0;
+    box-shadow: 2px 2px 2px #888;
+  }
+
   #bottom #notes div.personal {
     float: right;
     border-left: 4px solid #999;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -641,6 +641,7 @@ div.rendered.form {
   border-radius: 0.5em;
   margin: 1em;
   padding: 0.25em;
+  min-height: 3em;
 }
 div.rendered.form label {
   display: block;
@@ -653,6 +654,9 @@ div.rendered.form .item {
 /*   overflow: hidden; */
   height: 1.25em;
   white-space: nowrap;
+}
+div.rendered.form span.count {
+  display: none;
 }
 div.rendered.form .item.barstyle0 { background-color: #bb73bb; }
 div.rendered.form .item.barstyle1 { background-color: #59b859; }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -506,6 +506,11 @@ function renderForm(form) {
       var key = $(this).attr('data-name');
       var sum = 0;
 
+      // add a counter label if we haven't already
+      if( $(this).has('span.count').length == 0 ) {
+        $(this).prepend('<span class="count"></span>');
+      }
+
       $(this).find('ul > li > *').each(function() {
         $(this).parent().parent().before(this);
       });
@@ -568,16 +573,24 @@ function renderForm(form) {
 
       // only start counting and sizing bars if we actually have usable data
       if(data) {
+        // number of unique responses
+        var total = 0;
         // double loop so we can handle re-renderings of the form
         $(this).find('.item').each(function() {
           var name = $(this).attr('data-value');
 
           if(key in data) {
-            var count = data[key][name];
+            var count = data[key]['responses'][name];
             if(count) { sum += count; }
+
+            total = data[key]['count'];
           }
         });
 
+        // insert the total into the counter label
+        $(this).find('span.count').each(function() {
+          $(this).text(total);
+        });
 
         $(this).find('.item').each(function() {
           var name     = $(this).attr('data-value');
@@ -585,7 +598,7 @@ function renderForm(form) {
           var oldSum   = $(this).attr('data-sum');
 
           if(key in data) {
-            var count = data[key][name] || 0;
+            var count = data[key]['responses'][name] || 0;
           }
           else {
             var count = 0;


### PR DESCRIPTION
This will put a label in the upper right of each answer with the number
of participants who've answered that question. Note that answers may be
updated, so the bars might change even though the response count
doesn't.

Fixes #325 
