### PR TITLE
Load the keymap with a relative path so static works

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -118,7 +118,7 @@ function loadSlides(load_slides, prefix) {
 }
 
 function loadKeyDictionaries () {
-  $.getJSON('/js/keyDictionary.json', function(data) {
+  $.getJSON('js/keyDictionary.json', function(data) {
     keycode_dictionary = data['keycodeDictionary'];
     keycode_shifted_keys = data['shiftedKeyDictionary'];
   });


### PR DESCRIPTION
The keymap json was loaded with an absolute path, meaning that when the
static page was loaded from disk, it was trying to read from the
absolute root of the filesystem. Oops :)

This doesn't correct for the `/control` issue. That is scheduled to be
addressed by allowing the interactive features to be disabled
programatically.

Fixes #333
