### PR TITLE
Allow form author to indicate correct option(s)

### DIFF
--- a/documentation/FORMS.rdoc
+++ b/documentation/FORMS.rdoc
@@ -63,20 +63,22 @@ The right hand side (answer) can be rendered in the following ways:
   marking one as default using an `x`. This accepts the tokenized form for a key
   and a full human readable string. If options are placed on multiple lines
   indented by 3+ spaces, then the output will be rendered as a bullet list.
+  For use as a quiz, you may mark correct answers with an `=`.
 
     smartphone = () iPhone () Android () other -> Any other phone not listed
 
     awake -> Are you paying attention? = (x) No () Yes
 
-    continent =
+    continent -> Which continent is largest? =
         () Africa
         () Americas
-        () Asia
+        (=) Asia
         () Australia
         () Europe
 
 [checkboxes]
   Works exactly like radio boxes, only using square brackets as delineators.
+  Use `x` to mark the default options and `=` to mark correct options.
 
     smartphone = [] iPhone [] Android [x] other -> Any other phone not listed
 
@@ -84,9 +86,10 @@ The right hand side (answer) can be rendered in the following ways:
   Surround options on the right hand side with curly brackets and a combo select
   box will be rendered. If you place the options on multiple lines, you can use
   the long tokenized form. The shorthand single line syntax supports keys only.
-  The default option may be specified by surrounding an option with parentheses.
+  The default option may be specified by surrounding an option with parentheses
+  and the correct option may be indicated with square brackets.
 
-    smartphone = {iPhone, Android, Other }
+    phoneos -> Which phone OS is developed by Google? = {iPhone, [Android], Other }
 
     smartphone = {iPhone, Android, (Other) }
 

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -234,6 +234,11 @@ div.zoomed {
         display: none;
       }
 
+      #preview .content form label.correct {
+        font-weight: 900;
+        border-bottom: 4px solid black;
+      }
+
       img#disconnected {
         margin: 0.5em 1em;
       }

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -643,6 +643,9 @@ div.rendered.form {
   padding: 0.25em;
   min-height: 3em;
 }
+div.rendered.form.element {
+  padding-left: 0.5em;
+}
 div.rendered.form label {
   display: block;
   font-weight: bold;
@@ -654,14 +657,23 @@ div.rendered.form .item {
 /*   overflow: hidden; */
   height: 1.25em;
   white-space: nowrap;
+  opacity: 0.5;
+  border-radius: 0 0.5em 0.5em 0;
+  margin: 2px 0;
+}
+div.rendered.form .item.correct {
+  font-weight: 900;
+  border-left: 4px solid black;
+  opacity: 1.0;
 }
 div.rendered.form span.count {
   display: none;
 }
+
 div.rendered.form .item.barstyle0 { background-color: #bb73bb; }
 div.rendered.form .item.barstyle1 { background-color: #59b859; }
 div.rendered.form .item.barstyle2 { background-color: #e3742f; }
-div.rendered.form .item.barstyle3 { background-color: #4848e8; }
+div.rendered.form .item.barstyle3 { background-color: #48a2ee; }
 div.rendered.form .item.barstyle4 { background-color: #f75d5d; }
 
 #notes .form.wrapper {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -534,15 +534,16 @@ function renderForm(form) {
           case 'radio':
           case 'checkbox':
             // Just render these directly and migrate the label to inside the span
-            var value = $(this).attr('value');
-            var label = $(this).next('label');
-            var text  = label.text();
+            var value   = $(this).attr('value');
+            var label   = $(this).next('label');
+            var classes = $(this).attr('class');
+            var text    = label.text();
 
             if(text.match(/^-+$/)) {
               $(this).remove();
             }
             else{
-              $(this).replaceWith('<div class="item barstyle'+style+'" data-value="'+value+'">'+text+'</div>');
+              $(this).replaceWith('<div class="item barstyle'+style+' '+classes+'" data-value="'+value+'">'+text+'</div>');
             }
             label.remove();
             break;
@@ -553,11 +554,12 @@ function renderForm(form) {
             parent = $(this).parent();
 
             $(this).children('option').each(function() {
-              var value = $(this).val();
-              var text  = $(this).text();
+              var value   = $(this).val();
+              var text    = $(this).text();
+              var classes = $(this).attr('class');
 
               if(! text.match(/^-+$/)) {
-                parent.append('<div class="item barstyle'+style+'" data-value="'+value+'">'+text+'</div>');
+                parent.append('<div class="item barstyle'+style+' '+classes+'" data-value="'+value+'">'+text+'</div>');
 
                 // loop style counter
                 style++; style %= max;


### PR DESCRIPTION
This extend's the form support to indicate correct options. These will
be highlighted in the presenter view and in the results, both in the
notes and when it's pushed to the display view.

For radio/select, just mark the correct option with an `=` sign, and for
select widgets, surround the correct response with square brackets.

Tangentially, this also slightly restyles the bar graph to make the the
options stand out better.

Updating the parsing engine also fixed another issue, so (yay)

Fixes #332
Fixes #214
