### PR TITLE
Avoid deprecation in call

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -13,7 +13,7 @@ require "#{here}/commandline_parser"
 require "#{here}/keymap"
 
 begin
-  require 'RMagick'
+  require 'rmagick'
 rescue LoadError
   # nop
 end


### PR DESCRIPTION
To avoid the following message :
[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead"
