### PR TITLE
cache presentation content

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -125,6 +125,9 @@ command :serve do |c|
   c.desc 'Enable remote code execution'
   c.switch [:x, :executecode]
 
+  c.desc 'Disable content caching'
+  c.switch :nocache
+
   c.desc 'Port on which to run'
   c.default_value "9090"
   c.flag [:p, :port]
@@ -183,6 +186,7 @@ To run it from presenter view, go to: [ #{url}/presenter ]
                   :verbose   => options[:verbose],
                   :review    => options[:review],
                   :execute   => options[:executecode],
+                  :nocache   => options[:nocache],
                   :bind      => options[:host],
     ) do |server|
       if options[:ssl]

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -140,6 +140,7 @@ class ShowOff < Sinatra::Application
     @@downloads = Hash.new # Track downloadable files
     @@cookie    = nil      # presenter cookie. Identifies the presenter for control messages
     @@current   = Hash.new # The current slide that the presenter is viewing
+    @@cache     = nil      # Cache slide content for subsequent hits
 
     # flush stats to disk periodically
     Thread.new do
@@ -954,7 +955,13 @@ class ShowOff < Sinatra::Application
     end
 
     def slides(static=false)
-      get_slides_html(:static=>static)
+      # if we have a cache and we're not asking to invalidate it
+      return @@cache if (@@cache and params['cache'] != 'clear')
+      content = get_slides_html(:static=>static)
+
+      # allow command line cache disabling
+      @@cache = content unless settings.nocache
+      content
     end
 
     def onepage(static=false)

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -102,10 +102,14 @@ function setupPreso(load_slides, prefix) {
 */
 }
 
-function loadSlides(load_slides, prefix) {
+function loadSlides(load_slides, prefix, reload) {
+  var url = loadSlidesPrefix + "slides";
+  if (reload) {
+    url += "?cache=clear";
+  }
 	//load slides offscreen, wait for images and then initialize
 	if (load_slides) {
-		$("#slides").load(loadSlidesPrefix + "slides", false, function(){
+		$("#slides").load(url, false, function(){
 			$("#slides img").batchImageLoad({
 			loadingCompleteCallback: initializePresentation(prefix)
 		})
@@ -927,7 +931,7 @@ function toggleDebug () {
 
 function reloadSlides () {
   if (confirm('Are you sure you want to reload the slides?')) {
-    loadSlides(loadSlidesBool, loadSlidesPrefix);
+    loadSlides(loadSlidesBool, loadSlidesPrefix, true);
     showSlide();
   }
 }


### PR DESCRIPTION
The first load will still take many seconds, but each subsequent load
will be nearly instantaneous. This will make the audience experience
much, much better.

Pressing _r_ to reload the content will expire the cache and starting
with the `--nocache` command-line switch will disable caching.
