### PR TITLE
More accurate bar graphs

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -508,7 +508,6 @@ function renderForm(form) {
     //console.log(data);
     form.children('div.form.element').each(function() {
       var key = $(this).attr('data-name');
-      var sum = 0;
 
       // add a counter label if we haven't already
       if( $(this).has('span.count').length == 0 ) {
@@ -587,7 +586,6 @@ function renderForm(form) {
 
           if(key in data) {
             var count = data[key]['responses'][name];
-            if(count) { sum += count; }
 
             total = data[key]['count'];
           }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -598,10 +598,10 @@ function renderForm(form) {
           $(this).text(total);
         });
 
+        var oldTotal = $(this).attr('data-total');
         $(this).find('.item').each(function() {
           var name     = $(this).attr('data-value');
           var oldCount = $(this).attr('data-count');
-          var oldSum   = $(this).attr('data-sum');
 
           if(key in data) {
             var count = data[key]['responses'][name] || 0;
@@ -610,14 +610,16 @@ function renderForm(form) {
             var count = 0;
           }
 
-          if(count != oldCount || sum != oldSum) {
-            var percent = (sum) ? ((count/sum)*100)+'%' : '0%';
+          if(count != oldCount || total != oldTotal) {
+            var percent = (total) ? ((count/total)*100)+'%' : '0%';
 
             $(this).attr('data-count', count);
-            $(this).attr('data-sum', sum);
             $(this).animate({width: percent});
           }
         });
+
+        // record the old total value so we only animate when it changes
+        $(this).attr('data-total', total);
       }
 
       $(this).addClass('rendered');


### PR DESCRIPTION
Now that we have a number of responses, let's use that to scale the bar
graphs instead of the sum of the options selected for that question. It's
a more straightforward way at looking at the results.
