### PR TITLE
Handle .break and .comment tags in the renderer

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -502,9 +502,11 @@ class ShowOff < Sinatra::Application
       content
     end
 
-    # find any lines that start with a <p>.(something) and turn them into <p class="something">
-    def update_p_classes(markdown)
-      markdown.gsub(/<p>\.(.*?) /, '<p class="\1">')
+    # Find any lines that start with a <p>.(something), remove the ones tagged with
+    # .break and .comment, then turn the remainder into <p class="something">
+    def update_p_classes(content)
+      content.gsub!(/<p>\.(?:break|comment).*<\/p>/, '')
+      content.gsub(/<p>\.(.*?) /, '<p class="\1">')
     end
 
     # replace custom markup with html forms


### PR DESCRIPTION
Markdown is kind of horrible and gets confused if a code block follows a
list. It needs a block level element between. This handles that by
recognizing a `.break` tag and just deleting it from the output.

Markdown builds all the things appropriately and the block level <p>
convinces it to start the new element, and then we just discard it.

This also lets us do the same thing with `.comment` tags.

Summary: any lines beginning with `.break` or `.comment` will not appear
in the output and will separate lists followed by code.

TODO: all this text munging makes me ill.
