### PR TITLE
More styling changes

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -200,6 +200,12 @@ div.zoomed {
         color: #ccc;
       }
 
+    #preso {
+      -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
+      -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
+      box-shadow:0 0 25px rgba(0,0,0,0.35);
+    }
+    
     #statusbar {
       height: 22px;
       line-height: 22px;
@@ -299,7 +305,7 @@ div.zoomed {
   #notes ul {
     list-style-type: disc;
   }
-
+  
   #notes .element {
     display: inline-block;
     width: 90%;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -321,39 +321,32 @@ img#disconnected {
  **********************************/
 
 .content table {
-    margin-left: auto;
-    margin-right: auto;
-    border-collapse:collapse;
-    width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+  border-collapse:collapse;
+  width: 90%;
+  font-size: .9em;
 }
 
-.content.small table {
-    width: 90%;
-}
-.content.smaller table {
-    width: 95%;
+.content thead {
+  border-bottom: 2px solid #ccc;
 }
 
-.content table th {
-    border-bottom: 2px solid #ccc;
-    padding: 0.5em;
+.content tr:not(:last-child) {
+  border-bottom: 1px solid #ccc;
 }
 
-.content table tr td {
-    border-right: 1px solid #eee;
-    border-bottom: 1px solid #efefef;
-    text-align: center;
-    padding: 0.5em;
+.content tbody tr:nth-child(2n+1) {
+  background-color: #f9f9f9;
 }
 
-.content table tr td:last-child {
-    border-right: none;
+.content td {
+  padding: .25em .5em;
 }
 
-.content table li {
-    list-style-type: disc;
+.content td:first-child {
+  border-right: 2px solid #ccc;
 }
-
 
 /**********************************
  ***      Sidebar styling       ***

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,18 +1,38 @@
 body {
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
-  background:#333;
+  color: #222;    
 }
 
 h1,
 h2,
-h3 { 
-  text-align: center; 
-  margin: 0.5em 0; 
+h3 {
+  margin: 8px 0;
+  padding: 0 8px;
+  font-weight: normal;
+}
+
+h1:first-child {
+  border-bottom: 2px solid #222;
 }
 
 pre { 
   margin: 1em 40px; 
-  padding: .25em; 
+  padding: .25em;
+}
+
+/* applies to inline code only */
+code {
+  padding: 2px 4px;
+  font-size: 1.1em;
+  background-color: #ededed;
+  border-radius: 4px;
+}
+
+pre code {
+  padding: unset;
+  font-size: unset;
+  background-color: unset;
+  border-radius: unset;
 }
 
 @media screen {
@@ -26,18 +46,17 @@ pre {
     padding:0;
   }
 
-
   #preso,
   .slide {
-      background: #fff;
-      width: 1024px;
-      height: 768px;
-      margin-left:auto;
-      margin-right:auto;
-      overflow:hidden;
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: cover;
+    background: #fff;
+    width: 1024px;
+    height: 768px;
+    margin-left:auto;
+    margin-right:auto;
+    overflow:hidden;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
   }
 
   .slide {
@@ -85,6 +104,27 @@ pre {
   }
 }
 
+/* plain (non-bullet) text */
+.content > p,
+.content > form > p {
+  margin: 1em;
+}
+
+.content > blockquote,
+.content > form > blockquote {
+  margin: 2em;
+}
+
+.content img {
+  display:block;
+  margin-left:auto;
+  margin-right:auto;
+}
+
+.cover h1 {
+  border: none;
+}
+
 .slide .center {
   text-align: center;
   position: relative;
@@ -94,23 +134,11 @@ pre {
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
- 
-/* plain (non-bullet) text */
-.content > p,
-.content > form > p {
-    margin: 1em;
-    text-align: center;
-}
-
-.content > blockquote,
-.content > form > blockquote {
-    margin: 2em;
-}
-
-.center img {
-    display:block;
-    margin-left:auto;
-    margin-right:auto;
+  
+.center h1,
+.center h2,
+.center h3 {
+  text-align: center;
 }
 
 /**********************************
@@ -165,12 +193,6 @@ pre {
 
 .code {
     white-space: pre;
-}
-
-.subsection h1 {
-    background: #008;
-    color: #fff;
-    padding: .25em;
 }
 
 /* make this invisible as possible, while still rendering so that wkhtmltopdf doesn't ignore it */

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -23,9 +23,6 @@ body {
       margin-left:auto;
       margin-right:auto;
       overflow:hidden;
-      -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
-      -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
-      box-shadow:0 0 25px rgba(0,0,0,0.35);
       background-repeat: no-repeat;
       background-position: center;
       background-size: cover;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -3,6 +3,18 @@ body {
   background:#333;
 }
 
+h1,
+h2,
+h3 { 
+  text-align: center; 
+  margin: 0.5em 0; 
+}
+
+pre { 
+  margin: 1em 40px; 
+  padding: .25em; 
+}
+
 @media screen {
   /* explicitly size parent elements so the screen blanker works */
   html, body{
@@ -135,8 +147,6 @@ body {
   font-size: 80%;
 }
 
-
-
 .content .incremental.hidden {
   visibility: hidden;
 }
@@ -163,8 +173,6 @@ body {
     padding: .25em;
 }
 
-h1,h2,h3 { text-align: center; margin: 0.5em 0; }
-
 /* make this invisible as possible, while still rendering so that wkhtmltopdf doesn't ignore it */
 .content h1.section_title {
   color: transparent !important;
@@ -173,8 +181,6 @@ h1,h2,h3 { text-align: center; margin: 0.5em 0; }
   margin: 0 !important;
   padding: 0 !important;
 }
-
-pre { margin: 1em 40px; padding: .25em; }
 
 .notes, .handouts, .instructor, .solguide { display: none }
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,3 +1,8 @@
+body {
+  font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+  background:#333;
+}
+
 @media screen {
   /* explicitly size parent elements so the screen blanker works */
   html, body{
@@ -5,8 +10,6 @@
   }
 
   body {
-    font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
-    background:#333;
     margin:0;
     padding:0;
   }

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -12,7 +12,7 @@ h3 {
 }
 
 h1:first-child {
-  border-bottom: 2px solid #222;
+  border-bottom: 3px solid #222;
 }
 
 pre { 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -501,8 +501,8 @@ img#disconnected {
 /* Add a Shell "code highlighting" style to resemble the look of a terminal window. */
 .content pre.highlight code.language-shell {
   display: block;
-  background-color: black;
-  color: green;
+  background-color: #111;
+  color: #00ff40;
   border: 2px solid #ddd;
   padding: 0.5em;
   overflow: hidden;


### PR DESCRIPTION
body now has a white background
slide shadow is now only applied in presenter view
font-family was moved outside of screen media query to apply in all formats
all text is now left justified unless .center class is applied to class

table fonts have been shrunk
table rows are now striped (shamelessly copied from bootstrap)
![screen shot 2016-01-19 at 2 31 17 pm](https://cloud.githubusercontent.com/assets/3277190/12434090/56eccb96-beb9-11e5-8dec-b8eb5dc8bd95.png)

inlinecode samples are highlighted in grey (again, see bootstrap)
shell scripts have a brighter green color
![screen shot 2016-01-19 at 2 27 56 pm](https://cloud.githubusercontent.com/assets/3277190/12434046/1d51daf2-beb9-11e5-95b2-519911ac5162.png)

subsection headers have been restyled
first h1 elements in page have a bottom border
![screen shot 2016-01-19 at 2 29 08 pm](https://cloud.githubusercontent.com/assets/3277190/12434034/114ee90c-beb9-11e5-81e8-f4a92d938788.png)

(sorry, this one isn't very well organized)
