### PR TITLE
Remove the /pdf endpoint

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -248,6 +248,15 @@ command [:static] do |c|
   end
 end
 
+desc 'Generate PDF version of presentation'
+arg_name 'name'
+long_desc 'Creates a PDF version of the presentation as {name}.pdf'
+command [:pdf] do |c|
+  c.action do |global_options,options,args|
+    ShowOff.do_static(['pdf'].concat args)
+  end
+end
+
 pre do |global,command,options,args|
   # Pre logic here
   # Return true to proceed; false to abourt and not call the

--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -113,9 +113,6 @@ tools that you should be familiar with.
 [Notes Window]
   Opens a separate and resizable instructor notes window.
 
-[Generate PDF]
-  A link to the <tt>PDFKit</tt> generated PDF file.
-
 [Single Page]
   Loads up all slides as a single monolithic page. Useful for printing or when an
   ancient browser is used.
@@ -262,7 +259,7 @@ Options are specified *after* the command.
 [<tt>-p, --password=arg</tt>] add password protection to your heroku site
 
 
-== <tt>showoff serve </tt>
+== <tt>showoff serve</tt>
 
 Serves the showoff presentation in the current directory
 
@@ -273,29 +270,21 @@ Options are specified *after* the command.
 [<tt>-p, --port=arg</tt>] Port on which to run <i>( default: <tt>9090</tt>)</i>
 
 
-== <tt>showoff static name</tt>
+== <tt>showoff static [name]</tt>
 
-Generate static version of presentation
+Generate static version of presentation with an optional supplemental materials type.
 
-= Printable Output
+== <tt>showoff pdf [name]</tt>
 
-To generate printable output or a PDF via your browser rendering engine of choice, simply browse to
-the <tt>/onepage</tt> view and print the page using your browser's native print function. You may
-also use a rendering engine such as PrinceXML[http://www.princexml.com] to print this page to a PDF.
+Generate PDF version of presentation with an optional output filename. This requires the <tt>pdfkit</tt>
+gem and the <tt>wkhtmltopdf</tt> rendering engine installed into your <tt>$PATH</tt>.
 
-If your browser doesn't generate acceptable output, Showoff can produce a PDF version using the
-<tt>wkhtmltopdf</tt> rendering engine.
+= Browser Printable Output
 
-To do this, you must install a few things first:
+You may also generate printable output or a PDF via your browser rendering engine of choice, simply browse to
+the <tt>/print</tt> endpoint and print the page using your browser's native print function. Another option is
+using a rendering engine such as PrinceXML[http://www.princexml.com] to print this page to a PDF.
 
-    gem install pdfkit
-
-You'll then need to install a version of <tt>wkhtmltopdf</tt> available at the {wkhtmltopdf repo}[http://code.google.com/p/wkhtmltopdf/wiki/compilation] (or <tt>brew install wkhtmltopdf</tt> on a mac) and make sure that <tt>wkhtmltopdf</tt> is in your path:
-
-    export $PATH="/location/to/my/wkhtmltopdf/0.9.9:$PATH"
-
-
-Then restart showoff, and navigate to <tt>/pdf</tt> (e.g. http://localhost:9090/pdf) of your presentation and a PDF will be generated with the browser.
 
 = Shell Auto Completion
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -42,7 +42,6 @@
           <a id="notesWindow" href="javascript:toggleNotes();" title="Enable the popout notes window.">Notes Window <i class="fa fa-clone"></i></a>
         </span>
         <span>
-          <a id="generatePDF" href="/pdf" title="Call out to wkhtmltopdf to generate a PDF.">Generate PDF</a>
           <a id="onePage" href="/onepage" title="Load the single page view. Useful for printing.">Single Page</a>
         </span>
       </span>


### PR DESCRIPTION
This ports the `/pdf` endpoint and ports that functionality to a new
`showoff pdf` command-line option. If users want the old functionality
of providing a PDF for download, they can save the generated PDF into
the `_files/share` directory. This allows the PDF to be generated once
instead of once for every user who wants it.

For example, `showoff pdf _files/share/mypreso.pdf`
