### PR TITLE
Remove the mostly useless /onepage endpoint

### DIFF
--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -41,11 +41,6 @@ web browser. The following URL paths are available for use by you and your audie
   control the presentation if enabled with the <tt>Enable Remote</tt>  button. Showoff
   tries to be intelligent about which slide change updates to track.
 
-[http://localhost:9090/onepage]
-  This will generate a single page representing your entire presentation. It is primarily
-  useful when a viewer has an older browser than cannot handle the transitions properly
-  or is a luddite ;-) and wants to scroll rather than page.
-
 [http://localhost:9090/print]
   This will generate printable version of your presentation, including any slides that
   were tagged as _printonly_. This view can be printed directly from the browser, or

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -969,13 +969,6 @@ class ShowOff < Sinatra::Application
       content
     end
 
-    def onepage(static=false)
-      @slides = get_slides_html(:static=>static, :toc=>true)
-      @favicon = settings.showoff_config['favicon']
-
-      erb :onepage
-    end
-
     def print(static=false)
       @slides = get_slides_html(:static=>static, :toc=>true, :print=>true)
       @favicon = settings.showoff_config['favicon']

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -42,7 +42,7 @@
           <a id="notesWindow" href="javascript:toggleNotes();" title="Enable the popout notes window.">Notes Window <i class="fa fa-clone"></i></a>
         </span>
         <span>
-          <a id="onePage" href="/onepage" title="Load the single page view. Useful for printing.">Single Page</a>
+          <a id="onePage" href="/" title="Switch to Display Window.">Switch Views</a>
         </span>
       </span>
       <span class="mobile">


### PR DESCRIPTION
Using the `/print` endpoint will get you a page more suitable for
printing, and if you truly want a single page for display, you can
generate a PDF and show that.
