### PR TITLE
Added a native print slides button

### DIFF
--- a/documentation/USAGE.rdoc
+++ b/documentation/USAGE.rdoc
@@ -108,9 +108,12 @@ tools that you should be familiar with.
 [Notes Window]
   Opens a separate and resizable instructor notes window.
 
-[Single Page]
-  Loads up all slides as a single monolithic page. Useful for printing or when an
-  ancient browser is used.
+[Print Slides]
+  Prints the slides using the browser's native print functionality. Many browsers allow
+  you to print to PDF.
+
+[Switch View]
+  Changes to the Display view that your audience normally sees.
 
 === Presenter Tools
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -234,6 +234,17 @@ function openNotes()
   }
 }
 
+function printSlides()
+{
+  try {
+    var printWindow = window.open('/print');
+    printWindow.window.print();
+  }
+  catch(e) {
+    console.log('Failed to open print window. Popup blocker?');
+  }
+}
+
 function askQuestion(question) {
   $("#questions ul").prepend($('<li/>').text(question));
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -42,6 +42,7 @@
           <a id="notesWindow" href="javascript:toggleNotes();" title="Enable the popout notes window.">Notes Window <i class="fa fa-clone"></i></a>
         </span>
         <span>
+          <a id="printSlides" href="javascript:printSlides();" title="Print slides using a new window.">Print Slides</a>
           <a id="onePage" href="/" title="Switch to Display Window.">Switch Views</a>
         </span>
       </span>


### PR DESCRIPTION
With the deprecation of the janky wkhtmltopdf integration, this give the
presenter the ability to quickly print off a copy of the slides, to PDF
even if the browser has that capability.
