### PR TITLE
Support commonmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'tilt', :git => 'https://github.com/raphink/tilt', :branch => 'commonmark'
+gem 'tilt', :git => 'https://github.com/rtomayko/tilt'
 
 group :development do
   gem "turn"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'tilt', :git => 'https://github.com/raphink/tilt', :branch => 'commonmark'
+
 group :development do
   gem "turn"
   gem "rack-test"

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -442,6 +442,9 @@ module MarkdownConfig
     when 'kramdown'
       Tilt.prefer Tilt::KramdownTemplate, "markdown"
 
+    when 'commonmarker'
+      Tilt.prefer Tilt::CommonMarkerTemplate, "markdown"
+
     else
       Tilt.prefer Tilt::RedcarpetTemplate, "markdown"
       require 'tilt'

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -443,6 +443,7 @@ module MarkdownConfig
       Tilt.prefer Tilt::KramdownTemplate, "markdown"
 
     when 'commonmarker'
+      require 'tilt/commonmarker'
       Tilt.prefer Tilt::CommonMarkerTemplate, "markdown"
 
     else

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -491,7 +491,7 @@ img#disconnected {
 }
 
 /* Add a Shell "code highlighting" style to resemble the look of a terminal window. */
-.content pre.highlight code.language-shell {
+.content pre code.language-shell {
   display: block;
   background-color: #111;
   color: #00ff40;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -131,15 +131,15 @@ function initializePresentation(prefix) {
 	setupSlideParamsCheck();
 
 
-  $('pre.highlight code').each(function(i, block) {
+  $('pre code').each(function(i, block) {
     try {
       hljs.highlightBlock(block);
     } catch(e) {
       console.log('Syntax highlighting failed on ' + $(this).closest('div.slide').attr('id'));
       console.log('Syntax highlighting failed for ' + $(this).attr('class'));
       console.log(e);
-    }
-  });
+      }
+    });
 
   $(".content form").submit(function(e) {
     e.preventDefault();

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "redcarpet"
   s.add_dependency      "nokogiri"
   s.add_dependency      "sinatra-websocket"
+  s.add_dependency      "commonmarker"
   # workaround a bad dependency in sinatra-websocket
   s.add_dependency      "thin", "~> 1.3"
 

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -43,7 +43,7 @@
 
   <script type="text/javascript">
     $(document).ready(function() {
-      $('pre.highlight code').each(function(i, block) {
+      $('pre code').each(function(i, block) {
         try {
           hljs.highlightBlock(block);
         } catch(e) {


### PR DESCRIPTION
Standards, standards, standards... and a nicer look on GitHub, too!

This PR might still require a few adjustments here and there.

One issue I see is that I had to remove the `highlight` CSS class condition for highlighting, because CommonMarker doesn't put it. Can you think of another way to do that properly?
