### PR TITLE
Replace File.exists by File.exist

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -83,7 +83,7 @@ class ShowOff < Sinatra::Application
 
     # Load configuration for page size and template from the
     # configuration JSON file
-    if File.exists?(ShowOffUtils.presentation_config_file)
+    if File.exist?(ShowOffUtils.presentation_config_file)
       showoff_json = JSON.parse(File.read(ShowOffUtils.presentation_config_file))
       settings.showoff_config = showoff_json
 
@@ -337,7 +337,7 @@ class ShowOff < Sinatra::Application
           # We allow specifying a new template even when default is
           # not given.
           if settings.pres_template.include?(slide.tpl) and
-              File.exists?(settings.pres_template[slide.tpl])
+              File.exist?(settings.pres_template[slide.tpl])
             template = File.open(settings.pres_template[slide.tpl], "r").read()
           end
         end
@@ -1144,7 +1144,7 @@ class ShowOff < Sinatra::Application
   # Load a slide file from disk, parse it and return the text of a code block by index
   def get_code_from_slide(path, index)
     slide = "#{path}.md"
-    return unless File.exists? slide
+    return unless File.exist? slide
 
     html = process_markdown(slide, File.read(slide), {})
     doc  = Nokogiri::HTML::DocumentFragment.parse(html)

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -32,7 +32,7 @@ class ShowOffUtils
   end
 
   def self.create(dirname,create_samples,dir='one')
-    Dir.mkdir(dirname) if !File.exists?(dirname)
+    Dir.mkdir(dirname) if !File.exist?(dirname)
     Dir.chdir(dirname) do
       if create_samples
         # create section
@@ -152,7 +152,7 @@ class ShowOffUtils
   # [:type] - the type of slide to create
   def self.add_slide(options)
 
-    add_new_dir(options[:dir]) if options[:dir] && !File.exists?(options[:dir])
+    add_new_dir(options[:dir]) if options[:dir] && !File.exist?(options[:dir])
 
     options[:type] = 'code' if options[:code]
 
@@ -276,7 +276,7 @@ class ShowOffUtils
   def self.showoff_sections(dir,logger)
     index = File.join(dir, ShowOffUtils.presentation_config_file)
     sections = nil
-    if File.exists?(index)
+    if File.exist?(index)
       data = JSON.parse(File.read(index))
       logger.debug data
       if data.is_a?(Hash)
@@ -330,7 +330,7 @@ class ShowOffUtils
 
   def self.get_config_option(dir, option, default = nil)
     index = File.join(dir, ShowOffUtils.presentation_config_file)
-    if File.exists?(index)
+    if File.exist?(index)
       data = JSON.parse(File.read(index))
       if data.is_a?(Hash)
         if default.is_a?(Hash)
@@ -393,7 +393,7 @@ class ShowOffUtils
   #
   # Returns true if the file was created
   def self.create_file_if_needed(filename,force)
-    if !File.exists?(filename) || force
+    if !File.exist?(filename) || force
       File.open(filename, 'w+') do |f|
         yield f
       end


### PR DESCRIPTION
File.exists? is deprecated since Ruby 2.2.0, replaced by File.exist? since Ruby 2.0.0 (breaks with Ruby < 2.0.0)
