### PR TITLE
Re-enables t/c hotkeys for TOC

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1025,7 +1025,8 @@ function toggleHelp () {
 }
 
 function toggleContents () {
-  $('#navmenu').toggle().trigger('click');
+  $('#feedbackSidebar, #sidebarExit').toggle();
+  $("#navigation").toggle();
 }
 
 function swipeLeft() {


### PR DESCRIPTION
This deliberately duplicates a bit of code because we want it to not
disable hotkeys, unlike when you hit the hamburger with a mouse. That
said, in the future, we should consolidate a little bit and make the
hotkey disabling a little less heavy handed.

Fixes #439
