### PR TITLE
Make the last TOC entry discoverable

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -283,6 +283,11 @@ function setupMenu() {
         .append(icon)
         .click(function() {
           $(this).next().toggle();
+
+          if( $(this).parent().is(':last-child') ) {
+            $(this).next().children('li').first()[0].scrollIntoView();
+          }
+
           return false;
         });
       sectionUL = $("<ul>");


### PR DESCRIPTION
When the last item is clicked, before this commit it was very hard to
see it open. Now, it will scroll the children menu entries into view.
This is a little weird on the display view, because the menu jumps a
little on that last entry, but there wasn't really a good way to make it
happen only in the presenter view.

YAY for inline functions! @marrero984 should be ashamed! haha

Fixes #385
