### PR TITLE
Execute code when multiple slides are in one file

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -103,14 +103,14 @@ function reportIssue() {
 
 // open browser to remote edit URL
 function editSlide() {
-  var slide = $("span#slideFile").text().replace(/\/\d+$/, '');
+  var slide = $("span#slideFile").text().replace(/:\d+$/, '');
   var link  = editUrl + slide + ".md";
   window.open(link);
 }
 
 // call the edit endpoint to open up a local file editor
 function openEditor() {
-  var slide = $("span#slideFile").text().replace(/\/\d+$/, '');
+  var slide = $("span#slideFile").text().replace(/:\d+$/, '');
   var link  = '/edit/' + slide + ".md";
   $.get(link);
 }


### PR DESCRIPTION
This changes the multislide number delimiter, which will also solve
another error case--that when the file is actually called 1.md or the
like. This catches the edit and online edit functions. Nothing else
should be affected.

For the record, all this string manipulation still makes me feel dirty.

Fixes #394
