### PR TITLE
Add `showoff skeleton` command

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -58,6 +58,20 @@ command [:create,:init] do |c|
   end
 end
 
+desc 'Build a showoff presentation from a showoff.json outling'
+arg_name 'dir_name'
+long_desc 'This command helps start a new showoff presentation by creating each slide listing in the showoff.json file.'
+command [:skeleton] do |c|
+
+  c.desc 'alternate json filename'
+  c.flag [:f,:file]
+
+  c.action do |global_options,options,args|
+    ShowOffUtils.skeleton(options[:f])
+    puts "done. run 'showoff serve' to see your slideshow"
+  end
+end
+
 desc 'Puts your showoff presentation into a gh-pages branch'
 long_desc 'Generates a static version of your presentation into your gh-pages branch for publishing to GitHub Pages'
 command :github do |c|

--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -617,6 +617,7 @@ The "add slide" feature can allow you to add the necessary boilerplate from your
 == Commands
 [<tt>add</tt>] Add a new slide at the end in a given dir
 [<tt>create</tt>] Create new showoff presentation
+[<tt>skeleton</tt>] Generate a full presentation based on a <tt>showoff.json</tt> outline
 [<tt>help</tt>] Shows list of commands or help for one command
 [<tt>heroku</tt>] Setup your presentation to serve on Heroku
 [<tt>github</tt>] Setup your presentation to serve on GitHub Pages

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -52,6 +52,28 @@ class ShowOffUtils
     end
   end
 
+  def self.skeleton(config)
+    if config
+      FileUtils.cp(config, '.')
+      ShowOffUtils.presentation_config_file = File.basename(config)
+    end
+
+    self.showoff_sections('.').each do |filename|
+      next if File.exist? filename
+
+      puts "Creating: #{filename}"
+      if filename.downcase.end_with? '.md'
+        FileUtils.mkdir_p File.dirname(filename)
+
+        File.open(filename, 'w+') do |f|
+          f.puts make_slide("#{filename.sub(/\.md$/, '')}")
+        end
+      else
+        FileUtils.mkdir_p filename
+      end
+    end
+  end
+
   HEROKU_GEMS_FILE = '.gems'
   HEROKU_BUNDLER_GEMS_FILE = 'Gemfile'
   HEROKU_CONFIG_FILE = 'config.ru'
@@ -273,7 +295,12 @@ class ShowOffUtils
     [code,lines,width]
   end
 
-  def self.showoff_sections(dir,logger)
+  def self.showoff_sections(dir, logger = nil)
+    unless logger
+      logger = Logger.new(STDOUT)
+      logger.level = Logger::WARN
+    end
+
     index = File.join(dir, ShowOffUtils.presentation_config_file)
     sections = nil
     if File.exist?(index)


### PR DESCRIPTION
This command will expand a `showoff.json` file and create markdown
files for each file listed. It will handle file, directory, and
hash sections.

Fixes #158
