### PR TITLE
disable jekyll on github pages

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -99,6 +99,7 @@ class ShowOffUtils
   # generate a static version of the site into the gh-pages branch
   def self.github
     ShowOff.do_static(nil)
+    FileUtils.touch 'static/.nojekyll'
     `git add -f static`
     sha = `git write-tree`.chomp
     tree_sha = `git rev-parse #{sha}:static`.chomp


### PR DESCRIPTION
https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/
