### PR TITLE
Adds the configured favicon to the presenter view

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -964,6 +964,7 @@ class ShowOff < Sinatra::Application
     end
 
     def presenter
+      @favicon   = settings.showoff_config['favicon']
       @issues    = settings.showoff_config['issues']
       @edit      = settings.showoff_config['edit'] if @review
       @@cookie ||= guid()


### PR DESCRIPTION
Prior to this commit, the configured favicon was shown on the display
view, but the presenter view always used the default.

Fixes #473
