### PR TITLE
A little whitespace all around callouts

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -800,7 +800,7 @@ form .element {
  **********************/
 
  .callout {
-   padding: 12px 0;
+   padding: 12px;
    min-height: 2em;
    border: 1px solid #222;
    border-radius: 4px;


### PR DESCRIPTION
Prior to this, text squashed up against the left/right sides
