### PR TITLE
Remove race condition causing slide resets

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -758,8 +758,7 @@ function connected() {
   $("img#disconnected").hide();
 
   try {
-    // If we are a presenter, then remind the server where we are
-    update();
+    // If we are a presenter, then remind the server who we are
     register();
   }
   catch (e) {}


### PR DESCRIPTION
When reloading the browser, sometimes the websocket would connect before
the current slide number had been determined and recorded. In this case,
the `connected()` hook would fire, which calls the `update()` method to
register current slide number on the server.

The thing is, we don't really need to do that. If we're reloading, the
server already knows what slide we'll be on. The only behaviour change
is the ede case in which the presenter loads from scratch a specific
slide, say from a bookmark, or if the server had been restarted or the
like. But it will only be a matter of seconds before the server is
updated anyway.

Fixes #479
