### PR TITLE
Prevent toolbar wrapping on long names

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -384,6 +384,17 @@ a.controls {
   }
 }
 
+@media screen and (max-width: 900px)
+{
+  #topbar .fa {
+    display: none;
+  }
+  .desktop a {
+    margin-right: 0.25em;
+  }
+}
+
+
 /* iPhone */
 /* Portrait */
 @media screen and (max-width: 480px)

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -17,17 +17,18 @@
 }
 
 #topbar {
+  display: flex;
+  flex-flow: row;
   line-height: 24px;
+  height: 24px;
   background: #222222;
   font-size: .55em;
   color: #fff;
-  padding: 0 1em;
 }
 
   #topbar a {
     text-decoration: none;
     color: #fff;
-    padding: .35em;
   }
 
   #topbar a:hover{
@@ -38,13 +39,24 @@
     color: #8affeb;
   }
 
+  #slideSource {
+    display: flex;
+    flex-shrink: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 0.5em;
+  }
+
   #links {
-    float: right;
+    display: flex;
+    flex-shrink: 0;
+    margin: 0 0 0 auto;
   }
 
   #links a {
     border: 1px solid #ccc;
     border-radius: 0.5em;
+    padding: .35em;
   }
 
   #links a.enabled {
@@ -56,7 +68,7 @@
   }
 
   .desktop span {
-    margin: 0 1em;
+    margin: 0 0.5em;
   }
 
 #presenterPopup {
@@ -362,6 +374,14 @@ a.controls {
   -webkit-border-radius: 0.5em;
   -khtml-border-radius: 0.5em;
   border-radius: 0.5em;
+}
+
+/* hide some elements when the screen is too small */
+@media screen and (max-width: 1000px)
+{
+  #slideSource label {
+    display: none;
+  }
 }
 
 /* iPhone */

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -19,11 +19,11 @@
 <div id="main">
   <div id="topbar">
     <span id="slideSource">
-      Source:
+      <label>Source:</label>
       <% if @request.host == 'localhost' %>
         <a href="javascript:openEditor();"><span id="slideFile"></span></a>
       <% else %>
-        <span id="slideFile">
+        <span id="slideFile" />
       <% end %>
     </span>
     <span id="links">

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -23,7 +23,7 @@
       <% if @request.host == 'localhost' %>
         <a href="javascript:openEditor();"><span id="slideFile"></span></a>
       <% else %>
-        <span id="slideFile" />
+        <span id="slideFile"></span>
       <% end %>
     </span>
     <span id="links">


### PR DESCRIPTION
Port the toolbar to use flex too. Tested scaling and breakpoint in Safari,
Chrome, Firefox and iPhone.

Fixes #486
