### PR TITLE
Allows you to choose the section type to use

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -302,13 +302,46 @@ display below the slide in the printed version..
 
     ~~~SECTION:handouts~~~
 
-    This is supplementary material that will only appear in the printed version.
+    This is supplementary material that will appear in the printed version.
 
     ~~~ENDSECTION~~~
 
-Handout notes are best viewed by printing the <tt>/onepage</tt> view from your browser. Each slide will
+Handout notes are best viewed by printing the <tt>/print</tt> view from your browser. Each slide will
 be printed on a new page and handout notes will be included below the slide contents. Handout notes can
 contain any markup that the slide itself can.
+
+== Adding Notes Sections
+
+You can add arbitrary section types by simply declaring them on a slide. All sections attached to
+a slide can be chosen from a flyaway tab widget in the notes field in the presenter. For example,
+if a slide contained the following notes sections,
+
+    ~~~SECTION:notes~~~
+    This is a presenter note example.
+    ~~~ENDSECTION~~~
+
+    ~~~SECTION:handouts~~~
+    This is supplementary material that will appear in the printed version.
+    ~~~ENDSECTION~~~
+
+    ~~~SECTION:guide~~~
+    This is an additional notes section that may be chosen from the tab bar.
+    ~~~ENDSECTION~~~
+
+then the section selector would contain <tt>notes</tt>, <tt>handouts</tt>, and <tt>guide</tt>.
+
+== Printing Notes Sections
+
+When printing the presentation, you can choose which notes section to attach below the slides.
+
+    # Prints the presenter notes
+    showoff static print notes
+
+    # Prints a section called "guide"
+    showoff static print guide
+
+By default, the <tt>handouts</tt> section will be attached. In other words, <tt>showoff static print</tt>
+will behave just like <tt>showoff static print handouts</tt>.
 
 = Other Tags
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -284,7 +284,7 @@ class ShowOff < Sinatra::Application
       end
     end
 
-    def process_markdown(name, content, opts={:static=>false, :pdf=>false, :print=>false, :toc=>false, :supplemental=>nil})
+    def process_markdown(name, content, opts={:static=>false, :pdf=>false, :print=>false, :toc=>false, :supplemental=>nil, :section=>nil})
       if settings.encoding and content.respond_to?(:force_encoding)
         content.force_encoding(settings.encoding)
       end
@@ -409,7 +409,7 @@ class ShowOff < Sinatra::Application
         sl = Tilt[:markdown].new(nil, nil, engine_options) { sl }.render
         sl = build_forms(sl, content_classes)
         sl = update_p_classes(sl)
-        sl = process_content_for_section_tags(sl, name)
+        sl = process_content_for_section_tags(sl, name, opts)
         sl = update_special_content(sl, @slide_count, name) # TODO: deprecated
         sl = update_image_paths(name, sl, opts)
 
@@ -466,30 +466,36 @@ class ShowOff < Sinatra::Application
     end
 
     # replace section tags with classed div tags
-    def process_content_for_section_tags(content, name = nil)
+    def process_content_for_section_tags(content, name = nil, opts = {})
       return unless content
 
       # because this is post markdown rendering, we may need to shift a <p> tag around
       # remove the tags if they're by themselves
-      result = content.gsub(/<p>~~~SECTION:([^~]*)~~~<\/p>/, '<div class="\1">')
+      result = content.gsub(/<p>~~~SECTION:([^~]*)~~~<\/p>/, '<div class="notes-section \1">')
       result.gsub!(/<p>~~~ENDSECTION~~~<\/p>/, '</div>')
 
       # shove it around the div if it belongs to the contained element
-      result.gsub!(/(<p>)?~~~SECTION:([^~]*)~~~/, '<div class="\2">\1')
+      result.gsub!(/(<p>)?~~~SECTION:([^~]*)~~~/, '<div class="notes-section \2">\1')
       result.gsub!(/~~~ENDSECTION~~~(<\/p>)?/, '\1</div>')
 
       # Turn this into a document for munging
       doc = Nokogiri::HTML::DocumentFragment.parse(result)
 
+      if opts[:section]
+        doc.css('div.notes-section').each do |section|
+          section.remove unless section.attr('class').split.include? opts[:section]
+        end
+      end
+
       filename = File.join(settings.pres_dir, '_notes', "#{name}.md")
       @logger.debug "personal notes filename: #{filename}"
-      if File.file? filename
+      if [nil, 'notes'].include? opts[:section] and File.file? filename
         # TODO: shouldn't have to reparse config all the time
         engine_options = ShowOffUtils.showoff_renderer_options(settings.pres_dir)
 
         # Make sure we've got a notes div to hang personal notes from
-        doc.add_child '<div class="notes"></div>' if doc.css('div.notes').empty?
-        doc.css('div.notes').each do |section|
+        doc.add_child '<div class="notes-section notes"></div>' if doc.css('div.notes-section.notes').empty?
+        doc.css('div.notes-section.notes').each do |section|
           text = Tilt[:markdown].new(nil, nil, engine_options) { File.read(filename) }.render
           frag = "<div class=\"personal\"><h1>Personal Notes</h1>#{text}</div>"
           note = Nokogiri::HTML::DocumentFragment.parse(frag)
@@ -879,7 +885,7 @@ class ShowOff < Sinatra::Application
       html.to_html
     end
 
-    def get_slides_html(opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil})
+    def get_slides_html(opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil, :section=>nil})
 
       sections = ShowOffUtils.showoff_sections(settings.pres_dir, @logger)
       files = []
@@ -1024,8 +1030,8 @@ class ShowOff < Sinatra::Application
       content
     end
 
-    def print(static=false)
-      @slides = get_slides_html(:static=>static, :toc=>true, :print=>true)
+    def print(static=false, section=nil)
+      @slides = get_slides_html(:static=>static, :toc=>true, :print=>true, :section=>section)
       @favicon = settings.showoff_config['favicon']
       erb :onepage
     end
@@ -1120,6 +1126,9 @@ class ShowOff < Sinatra::Application
       when 'pdf'
         opt ||= "#{name}.pdf"
         data = showoff.send(what, opt)
+      when 'print'
+        opt ||= 'handouts'
+        data = showoff.send(what, true, opt)
       else
         data = showoff.send(what, true)
       end

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1037,7 +1037,8 @@ class ShowOff < Sinatra::Application
     end
 
     def supplemental(content, static=false)
-      @slides = get_slides_html(:static=>static, :supplemental=>content)
+      # supplemental material is by definition separate from the presentation, so it doesn't make sense to attach notes
+      @slides = get_slides_html(:static=>static, :supplemental=>content, :section=>false)
       @favicon = settings.showoff_config['favicon']
       @wrapper_classes = ['supplemental']
       erb :onepage

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -331,6 +331,35 @@
     padding: 0 1em;
   }
 
+  #notes ul.section-selector {
+    padding: 0;
+    margin: 0 0 0 -1.25em;         /* compensate for the border on #notes. 1/0.8 em */
+    text-align: center;
+    border-bottom: 1px solid #ccc;
+    font-size: 0.8em;
+    position: absolute;
+    background-color: #F5ED9B;
+  }
+  #notes ul.section-selector li {
+    display: none;
+    padding: 0 1em;
+  }
+  #notes ul.section-selector li:hover {
+    background-color: #b9b9b9;
+    transition-duration: 0.5s;
+  }
+  #notes ul.section-selector li.selected {
+    display: inline;
+    background-color: #ccc;
+  }
+  #notes ul.section-selector:hover li {
+    display: inline;
+  }
+
+  #notes ul.section-selector li a {
+    text-decoration: none;
+  }
+
   #notes ol { list-style-type: decimal; }
   #notes ul { list-style-type: disc; }
 
@@ -354,7 +383,7 @@
     border-bottom: 4px solid #999;
     border-radius: 0 0 0 0.5em;
     padding: 0.1em 0 0.25em 0.25em;
-    margin: 0 0 1em 1em;
+    margin: 0 -1em 1em 1em;                  /* compensate for the padding in the #notes section */
     background: #eee;
     max-width: 25%;
   }
@@ -364,6 +393,11 @@
     border-bottom: 1px solid #ccc;
     font-size: 1.5em;
   }
+
+  #notes .pagebreak {
+    display: none;
+  }
+
 
 a.controls {
   text-decoration: none;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -213,7 +213,7 @@ pre code {
     white-space: pre;
 }
 
-.notes, .handouts, .instructor, .solguide { display: none }
+.notes-section, .instructor, .solguide { display: none }
 
 .offscreen { position:absolute; top:0; left:-9999px; overflow:hidden; }
 
@@ -547,7 +547,7 @@ img#disconnected {
   right: .5em;
 }
 
-.executing:after { 
+.executing:after {
   content: "\f1ce";
   color: #e74c3c;
   -webkit-animation: spin 1.5s linear infinite;
@@ -893,19 +893,35 @@ form .element {
   }
 
   /* Styling to make the handout notes appear in the printed output. */
-  .handouts {
+  .notes-section {
     display: block;
     clear: both;
     padding-top: 1em;
   }
 
   /* prepend the first element of the .handouts div with Notes: */
-  .handouts > :first-child:before {
+  .notes-section > :first-child:before {
     display: block;
     font-weight: bold;
     content: "Notes:";
     border-top: 2px dashed #999;
     padding: 0.25em 0 0.5em 0;
+  }
+
+  .notes-section.notes .personal {
+    float: right;
+    border-left: 2px solid #999;
+    border-bottom: 2px solid #999;
+    border-radius: 0 0 0 0.5em;
+    padding: 0.1em 0 0.25em 0.25em;
+    margin: 0 0 1em 1em;
+    max-width: 35%;
+  }
+
+  .notes-section.notes .personal h1 {
+    margin-top: 0;
+    border-bottom: 1px solid #ccc;
+    font-size: 1.5em;
   }
 
   /* page break styling */

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -414,7 +414,25 @@ function postSlide() {
       notes = notes.html();
     }
 
-		$('#notes').html(notes);
+    $('#notes').html(notes);
+
+    var sections = getCurrentSections();
+    if(sections.size() > 1) {
+      var ul = $('<ul>').addClass('section-selector');
+      sections.each(function(idx, value){
+        var li = $('<li/>').appendTo(ul);
+        var a  = $('<a/>')
+                      .text(value)
+                      .attr('href','javascript:setCurrentSection("'+value+'");')
+                      .appendTo(li);
+
+        if(section == value) {
+          li.addClass('selected');
+        }
+      });
+
+      $('#notes').prepend(ul);
+    }
 
     if (notesWindow && typeof(notesWindow) != 'undefined' && !notesWindow.closed) {
       $(notesWindow.document.body).html(notes);

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -16,7 +16,8 @@ var incrCode = false
 var debugMode = false
 var gotoSlidenum = 0
 var lastMessageGuid = 0
-var query
+var query;
+var section = 'notes'; // which section the presenter has chosen to view
 var slideStartTime = new Date().getTime()
 
 var loadSlidesBool
@@ -501,9 +502,22 @@ function getSlideProgress()
 	return (slidenum + 1) + '/' + slideTotal
 }
 
+function getCurrentSections()
+{
+  return currentSlide.find("div.notes-section").map(function() {
+    return $(this).attr('class').split(' ').filter(function(x) { return x != 'notes-section'; });
+  });
+}
+
+function setCurrentSection(newSection)
+{
+  section = newSection;
+  postSlide();
+}
+
 function getCurrentNotes()
 {
-    var notes = currentSlide.find("div.notes");
+    var notes = currentSlide.find("div.notes-section."+section);
     return notes;
 }
 
@@ -657,7 +671,7 @@ function renderForm(form) {
                 .attr('data-value', $(input).attr('value'))
                 .append($('<span>').addClass('answer').text(text))
                 .append($('<div>').addClass('bar'));
-                
+
               if (classes) {
                 resultDiv.addClass(classes);
               }


### PR DESCRIPTION
This adds two related features. Both of the features work with section
tags, such as:

```
~~~SECTION:notes~~~
This text is inside a "notes" section.
~~~ENDSECTION~~~
```

Prior to this, there were two types of sections, `notes` and `handouts`.
Now, the types are arbitrary. You can add any section types you want by
simply declaring them in a slide.

When viewing the presenter, any time there are more than one sections
attached to a slide, you'll now be presented with a flyaway tab widget
that will allow you to choose any of the sections to display in the
`#notes` field. The choice is persistent, so if you switch to the
`guide` section, then it will stay that way until you change it.

When printing, you can now choose the section type to attach as notes.

```
# Prints the presenter notes
showoff static print notes

# Prints a section called "guide"
showoff static print guide
```

The existing section types, `notes` and `handouts`, are retained in that
the default type to show in the `#notes` field is the `notes` section
and the default type to print is the `handouts` section. Personal notes
will also only attach to the `notes` section type.

Fixes #489
