### PR TITLE
Don't show interactivity features when static

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -968,6 +968,9 @@ class ShowOff < Sinatra::Application
       # Check to see if the presentation has enabled feedback
       @feedback = settings.showoff_config['feedback'] unless (params && params[:feedback] == 'false')
 
+      # If we're static, we need to not show the downloads page
+      @static   = static
+
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -14,8 +14,10 @@
     <h3>Showoff Menu</h3>
     <div id="navToggle" class="buttonWrapper"><i class=" fa fa-bookmark"></i> Table of Contents</div>
     <div id="navigation" class="submenu"></div>
+    <% if not @static then %>
     <hr>
     <div id="fileDownloads" class="buttonWrapper"><i class="fa fa-download"></i> Downloads</div>
+    <% end %>
     <hr>
 
     <% if @feedback then %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -20,7 +20,7 @@
     <% end %>
     <hr>
 
-    <% if @feedback then %>
+    <% if @feedback and not @static then %>
         <p>The presenter should...</p>
         <div id="paceSlower" class="buttonWrapper split">
         <i class="fa fa-minus"></i>


### PR DESCRIPTION
There's nothing there to show anyway! This has a couple things I don't
like. Namely that the TOC should start open when it's the only thing
here, but since we're using toggles all over I could not figure out a
completely reliable way to set its state.
