### PR TITLE
We don't really need the label anyway

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -862,19 +862,12 @@ form .element {
   #notes {
     display: block;
     clear: both;
-    padding: 1em 0.25em 3em;
+    margin: 1em 0.25em 3em;
     font-size: 9pt;
-  }
-
-  /* prepend the first element of the .handouts div with Notes: */
-  #notes > :first-child:before {
-    display: block;
-    font-weight: bold;
-    content: "Notes:";
     border-top: 2px dashed #999;
-    padding: 0.25em 0 0.5em 0;
   }
 }
+
 /* Show button navigation on touch screen devices. */
 @media screen and (pointer: coarse)
 {
@@ -902,7 +895,6 @@ form .element {
     content: "\f054";
     padding-left: 0.25em;
   }
-
 }
 
 /** Print **/
@@ -946,16 +938,8 @@ form .element {
   .notes-section {
     display: block;
     clear: both;
-    padding-top: 1em;
-  }
-
-  /* prepend the first element of the .handouts div with Notes: */
-  .notes-section > :first-child:before {
-    display: block;
-    font-weight: bold;
-    content: "Notes:";
+    margin-top: 1em;
     border-top: 2px dashed #999;
-    padding: 0.25em 0 0.5em 0;
   }
 
   .notes-section.notes .personal {


### PR DESCRIPTION
It adds little, and makes it harder to internationalize. If you'd like
to get the old behaviour, you can add this to your own preso stylesheet.

Fixes #492
