### PR TITLE
This prevents weirdness when blanking.

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -44,6 +44,7 @@ pre code {
   body {
     margin:0;
     padding:0;
+    overflow: hidden;
   }
 
   #preso,


### PR DESCRIPTION
Prior to this, if you blanked, then hit the right arrow, it scrolled to
the bottom, which looked like a slide change. Then you'd zip along
presenting for a while until you hit the left arrow to go back and it
would scroll back up, or "blank".

Instead, let's just not scroll, yeah?

And in a happy but not too surprising coincidence, this also fixes the
IE eagerness to scroll all over.

Fixes #481
