### PR TITLE
align icon to first line of callout; no text wrapping under icon

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -822,7 +822,7 @@ form .element {
 
  .callout {
    padding: 12px;
-   min-height: 2em;
+   line-height: 1.6em;
    border: 1px solid #222;
    border-radius: 4px;
    background-color: transparent; /* because there's a warning class with a red background */
@@ -834,7 +834,7 @@ form .element {
    font-weight: normal;
    font-size: 2em;
    text-decoration: inherit;
-   padding: 0 8px;
+   padding: 0 8px 100% 8px;
    float: left;
  }
 


### PR DESCRIPTION
![screen shot 2016-06-07 at 1 34 29 pm](https://cloud.githubusercontent.com/assets/3277190/15873820/40a9610e-2cb5-11e6-93b3-a8d3a4788f2b.png)
![screen shot 2016-06-07 at 1 34 23 pm](https://cloud.githubusercontent.com/assets/3277190/15873821/40cbedf0-2cb5-11e6-9bb9-2906fb206640.png)
