### PR TITLE
This just adds some sample section slides

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -42,6 +42,9 @@ class ShowOffUtils
           FileUtils.mkdir_p(dir)
 
           # create markdown file
+          File.open("#{dir}/00_section.md", 'w+') do |f|
+            f.puts make_slide("Section Header", "center subsection")
+          end
           File.open("#{dir}/01_slide.md", 'w+') do |f|
             f.puts make_slide("My Presentation")
           end
@@ -81,7 +84,12 @@ class ShowOffUtils
         FileUtils.mkdir_p File.dirname(filename)
 
         File.open(filename, 'w+') do |f|
-          f.puts make_slide("#{filename.sub(/\.md$/, '')}")
+          if filename =~ /section/i
+            # kind of looks like a section slide
+            f.puts make_slide("#{filename.sub(/\.md$/, '')}", "center subsection")
+          else
+            f.puts make_slide("#{filename.sub(/\.md$/, '')}")
+          end
         end
       else
         FileUtils.mkdir_p filename


### PR DESCRIPTION
When you run `showoff init`, this will generate a section slide for each
directory.

When you run `showoff skeleton`, this will generate a section slide for
each slide with a name that has the word section in it.
