### PR TITLE
Ticket/357/make regex less greedy

### DIFF
--- a/documentation/PRESENTATION.rdoc
+++ b/documentation/PRESENTATION.rdoc
@@ -196,6 +196,7 @@ with showoff. The following engines are available:
 - maruku
 - kramdown
 - rdiscount
+- commonmark
 
 You may configure special options of your markdown engine by including an
 options hash keyed off the markdown engine name in your configuration file.

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -453,7 +453,7 @@ class ShowOff < Sinatra::Application
       end
 
       # Load and replace any file tags
-      content.scan(/(~~~FILE:([^:]*):?(.*)?~~~)/).each do |match|
+      content.scan(/(~~~FILE:([^:~]*):?(.*)?~~~)/).each do |match|
         # make a list of code highlighting classes to include
         css  = match[2].split.collect {|i| "language-#{i.downcase}" }.join(' ')
 

--- a/test/fixtures/complete/files/including.md
+++ b/test/fixtures/complete/files/including.md
@@ -1,0 +1,20 @@
+!SLIDE
+# Including files
+
+This slide includes a file in the `_files` directory without spcific highlighting.
+The highlight engine will pick what it thinks is best.
+
+~~~FILE:test.rb~~~
+
+This will highlight it as Ruby code..
+
+~~~FILE:test.rb:Ruby~~~
+
+~~~SECTION:notes~~~
+This is an instructor note.
+~~~ENDSECTION~~~
+
+~~~SECTION:handouts~~~
+This is a handout note
+~~~ENDSECTION~~~
+

--- a/test/fixtures/complete/showoff.json
+++ b/test/fixtures/complete/showoff.json
@@ -16,7 +16,8 @@
     "third/slide.md",
     "third/code.md",
     "fourth/slide.md",
-    "fourth/image.md"
+    "fourth/image.md",
+    "files/including.md"
   ]
 }
 


### PR DESCRIPTION
When multiple tags (such as a SECTION) were included on a slide and the
file options did not include the syntax highlighing type, then the regex
was too greedy and matched until the end of the next tag. This fixes
that.

Fixes #357
