### PR TITLE
Add the ability to serve a git URL

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -146,7 +146,7 @@ command :serve do |c|
   c.switch [:r, :review]
 
   c.desc 'Enable remote code execution'
-  c.switch [:x, :executecode]
+  c.switch [:x, :execute, :executecode]
 
   c.desc 'Run in standalone mode, with no audience interaction'
   c.switch [:S, :standalone]
@@ -175,6 +175,9 @@ command :serve do |c|
   c.default_value "showoff.json"
   c.flag [:f, :file, :pres_file]
 
+  c.desc 'Git URL to a repository containing the presentation'
+  c.flag [:u, :url]
+
   c.action do |global_options,options,args|
 
     # This is gross. A serious revamp in config file parsing is due.
@@ -189,6 +192,15 @@ command :serve do |c|
     options[:ssl_certificate] ||= config['ssl_certificate']
     options[:ssl_private_key] ||= config['ssl_private_key']
     options[:standalone]      ||= config['standalone']
+
+    options[:pres_dir]          = args[0]
+    options[:port]              = options[:port].to_i
+
+    ssl_options = {
+      :cert_chain_file  => options[:ssl_certificate],
+      :private_key_file => options[:ssl_private_key],
+      :verify_peer      => false,
+    }
 
     protocol = options[:ssl] ? 'https' : 'http'
     host     = options[:host] == '0.0.0.0' ? 'localhost' : options[:host]
@@ -206,26 +218,22 @@ To run it from presenter view, go to: [ #{url}/presenter ]
 
 "
 
-    ShowOff.run!( :host       => options[:host],
-                  :port       => options[:port].to_i,
-                  :pres_file  => options[:file],
-                  :pres_dir   => args[0],
-                  :verbose    => options[:verbose],
-                  :review     => options[:review],
-                  :execute    => options[:executecode],
-                  :nocache    => options[:nocache],
-                  :bind       => options[:host],
-                  :standalone => options[:standalone],
-    ) do |server|
-      if options[:ssl]
-        ssl_options = {
-          :cert_chain_file  => options[:ssl_certificate],
-          :private_key_file => options[:ssl_private_key],
-          :verify_peer      => false,
-        }
+    if options[:url]
+      ShowOffUtils.clone(options[:url], options[:verbose]) do
+        ShowOff.run!(options) do |server|
+          if options[:ssl]
+            server.ssl         = true
+            server.ssl_options = ssl_options
+          end
+        end
+      end
 
-        server.ssl = true
-        server.ssl_options = ssl_options
+    else
+      ShowOff.run!(options) do |server|
+        if options[:ssl]
+          server.ssl         = true
+          server.ssl_options = ssl_options
+        end
       end
     end
 

--- a/documentation/COMMANDLINE.rdoc
+++ b/documentation/COMMANDLINE.rdoc
@@ -84,11 +84,12 @@ Options are specified *after* the command.
 
 Serves the showoff presentation in the current directory
 
-Options are specified *after* the command.
+Options are specified *after* the command. More arguments can be seen by running <tt>showoff serve --help</tt>.
 
 [<tt>-f, --pres_file=arg</tt>] Presentation file <i>(default: <tt>showoff.json</tt>)</i>
 [<tt>-h, --host=arg</tt>] Host or ip to run on <i>( default: <tt>localhost</tt>)</i>
 [<tt>-p, --port=arg</tt>] Port on which to run <i>( default: <tt>9090</tt>)</i>
+[<tt>-u, --url=address</tt>] Git URL to a repository containing the presentation <i>( default: <tt>none</tt>)</i>
 
 
 == <tt>showoff skeleton</tt>

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -204,6 +204,20 @@ class ShowOffUtils
     `git update-ref refs/heads/gh-pages #{commit_sha}`
   end
 
+  # clone a repo url, then run a provided block
+  def self.clone(url, verbose=false)
+    require 'tmpdir'
+    Dir.mktmpdir do |dir|
+      Dir.chdir dir do
+        puts "Cloning presentation repository to #{dir}..." if verbose
+        system('git', 'clone', '--depth', '1', url, '.')
+
+        yield if block_given?
+      end
+    end
+
+  end
+
   # Makes a slide as a string.
   # [title] title of the slide
   # [classes] any "classes" to include, such as 'smaller', 'transition', etc.


### PR DESCRIPTION
This will create a temporary directory and shallow clone the repo. After
done serving, the directory will be automatically cleaned up.
