### PR TITLE
Add dockerdockerdocker stuff

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,38 @@
+require 'fileutils'
+
 task :default do
   system("rake -T")
 end
 
+def version
+  `git describe --tags  --abbrev=0`.chomp.sub('v','')
+end
+
+def next_version(type = :patch)
+  section = [:major,:minor,:patch].index type
+
+  n = version.split '.'
+  n[section] = n[section].to_i + 1
+  n.join '.'
+end
+
+desc "Build Docker image"
+task 'docker' do
+  Dir.chdir('build') do
+    system("docker build -t binford2k/showoff:#{version} -t binford2k/showoff:latest .")
+  end
+  puts
+  puts 'Start container with: docker run -p 9090:9090 binford2k/showoff'
+end
+
+desc "Upload image to Docker Hub"
+task 'docker:push' => ['docker'] do
+  system("docker push binford2k/showoff:#{version}")
+  system("docker push binford2k/showoff:latest")
+end
+
 desc "Build HTML documentation"
 task :doc do
-  require 'fileutils'
-
   FileUtils.rm_rf('doc')
   Dir.chdir('documentation') do
     system("rdoc --main -HOME.rdoc /*.rdoc --op ../doc")
@@ -14,8 +41,6 @@ end
 
 desc "Update docs for webpage"
 task 'doc:website' => [:doc] do
-  require 'fileutils'
-
   if system('git checkout gh-pages')
     FileUtils.rm_rf('documentation')
     FileUtils.mv('doc', 'documentation')

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,8 @@
+FROM gliderlabs/alpine
+MAINTAINER Ben Ford <ben.ford@puppet.com>
+WORKDIR /var/cache/showoff
+RUN apk add --no-cache ruby ruby-dev zlib-dev build-base git \
+        && gem install showoff --no-ri --no-rdoc             \
+        && apk del --purge binutils-libs binutils isl libgomp libatomic mpfr3 mpc1 gcc make musl-dev libc-dev fortify-headers g++ build-base
+
+CMD ["showoff", "serve"]

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -1,0 +1,13 @@
+FROM binford2k/showoff
+MAINTAINER Your Name <your.email@address.com>
+WORKDIR /var/cache/showoff
+
+# Uncomment and edit this to clone a repository as a presentation
+#RUN git clone --depth 1 https://github.com/binford2k/catalog_security.git . && rm -rf .git
+
+# Uncomment and edit this to copy presentation files to your container
+#ADD * /var/cache/showoff/
+
+# Uncomment and edit these to configure runtimes for live code execution
+#RUN apk add --no-cache perl python
+#CMD ["showoff", "serve", "-x"]


### PR DESCRIPTION
This adds rake tasks to build and push docker images so we can easily
keep them maintained. This uses my namespace for now, since it's
unlikely that we'll get access to the `puppetlabs` namespace on hub.

Maybe we should register `puppetlabs-education`? Dunno, this seems ok
for now.

This also provides an example `Dockerfile` for people to build their own
images containing their presentations.
