### PR TITLE
Reload the page when content is reloaded

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1148,6 +1148,7 @@ function toggleDebug () {
 
 function reloadSlides () {
   if (confirm('Are you sure you want to reload the slides?')) {
+    location.reload(true);
     loadSlides(loadSlidesBool, loadSlidesPrefix, true);
     showSlide();
   }


### PR DESCRIPTION
This will refresh styles along with content updates when you trigger the
refresh function. It adds a negligible amount of time to the reload,
since most of that was in presentation compilation anyway. It also
provides feedback that _something_ is happening, instead of just a long
pause and then slides redrawing.

Do you think this would meet your needs, @nathanl ?

Fixes #534
