### PR TITLE
Made reloading content more reliable

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -82,18 +82,21 @@ function loadSlides(load_slides, prefix, reload) {
   if (reload) {
     url += "?cache=clear";
   }
-	//load slides offscreen, wait for images and then initialize
-	if (load_slides) {
-		$("#slides").load(url, false, function(){
-			$("#slides img").batchImageLoad({
-			loadingCompleteCallback: initializePresentation(prefix)
-		})
-		})
-	} else {
-	$("#slides img").batchImageLoad({
-		loadingCompleteCallback: initializePresentation(prefix)
-	})
-	}
+  //load slides offscreen, wait for images and then initialize
+  if (load_slides) {
+    $("#slides").load(url, false, function(){
+      $("#slides img").batchImageLoad({
+        loadingCompleteCallback: initializePresentation(prefix)
+      });
+      if (reload) {
+        location.reload(true);
+      }
+    })
+  } else {
+    $("#slides img").batchImageLoad({
+      loadingCompleteCallback: initializePresentation(prefix)
+    })
+  }
 }
 
 function initializePresentation(prefix) {
@@ -1148,7 +1151,7 @@ function toggleDebug () {
 
 function reloadSlides () {
   if (confirm('Are you sure you want to reload the slides?')) {
-    location.reload(true);
+    $('html,body').css('cursor','progress');
     loadSlides(loadSlidesBool, loadSlidesPrefix, true);
     showSlide();
   }


### PR DESCRIPTION
We recently added full reloading of the UI (#535) so that styles, etc.
were updated along with content when the `reload` function was triggered.
Unfortunately, that had the side effect of redrawing content before the
new presentation had completed compilation. In other words, it would
reload with the old content, and you'd have to wait a few seconds and
hit it again before you'd see changes.

This corrects that. It also cleans up some boogered indentation.

Fixes #540
