### PR TITLE
Adds primitive annotation support

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -391,6 +391,8 @@ class ShowOff < Sinatra::Application
           content += "<div class=\"content #{classes}\" ref=\"#{name}\">\n"
         end
 
+        content += "  <canvas class=\"annotations\"></canvas>\n"
+
         # renderers like wkhtmltopdf needs an <h1> tag to use for a section title, but only when printing.
         if opts[:print]
           # reset subsection each time we encounter a new subsection slide. Do this in a regex, because it's much
@@ -1457,6 +1459,9 @@ class ShowOff < Sinatra::Application
 
             when 'complete'
               EM.next_tick { settings.sockets.each{|s| s.send(control.to_json) } }
+
+            when 'annotation', 'annotationConfig'
+              EM.next_tick { (settings.sockets - settings.presenters).each{|s| s.send(control.to_json) } }
 
             when 'feedback'
               filename = "#{settings.statsdir}/#{settings.feedback}"

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -391,8 +391,6 @@ class ShowOff < Sinatra::Application
           content += "<div class=\"content #{classes}\" ref=\"#{name}\">\n"
         end
 
-        content += "  <canvas class=\"annotations\"></canvas>\n"
-
         # renderers like wkhtmltopdf needs an <h1> tag to use for a section title, but only when printing.
         if opts[:print]
           # reset subsection each time we encounter a new subsection slide. Do this in a regex, because it's much
@@ -415,6 +413,7 @@ class ShowOff < Sinatra::Application
 
         content += sl
         content += "</div>\n"
+        content += "<canvas class=\"annotations\"></canvas>\n"
         content += "</div>\n"
 
         final += update_commandline_code(content)

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -106,8 +106,8 @@
     display:         flex;
     -webkit-flex-flow: column;
             flex-flow: column;
-    -webkit-flex: 1;
-            flex: 1;
+    -webkit-flex: 2;
+            flex: 2;
     -webkit-order: 0;
             order: 0;
     min-width: 210px;
@@ -210,8 +210,8 @@
     display:         flex;
     -webkit-flex-flow: column;
             flex-flow: column;
-    -webkit-flex: 4;
-            flex: 4;
+    -webkit-flex: 10;
+            flex: 10;
     -webkit-order: 1;
             order: 1;
     min-width: 0px;
@@ -224,7 +224,6 @@
       background: #eee;
       padding: 1em;
     }
-
       #preview input[type=button].display {
         display: inline;
       }
@@ -266,7 +265,8 @@
         display: inline;
       }
       #enableFollower,
-      #enableRemote {
+      #enableRemote,
+      #enableAnnotations {
         float: right;
         margin: 1px;
         padding: 0.1em;
@@ -277,6 +277,52 @@
         -moz-box-shadow: 0px 0px 15px 5px rgba(255, 255, 190, .75);
         box-shadow: 0px 0px 15px 5px rgba(255, 255, 190, .75);
       }
+
+  #annotationToolbar {
+    display: -webkit-flex;
+    display:         flex;
+    -webkit-flex-flow: column;
+            flex-flow: column;
+    -webkit-flex: 0.5;
+            flex: 0.5;
+    -webkit-order: 2;
+            order: 2;
+    min-width: 48px;
+    width: 48px;
+    padding: 0;
+    margin: 0;
+    background-color: black;
+    color: white;
+    text-align: center;
+  }
+    #annotationToolbar label {
+      font-size: 0.8em;
+      padding-top: 1em;
+      margin-bottom: 1px;
+      border-bottom: 1px solid #ccc;
+    }
+    #annotationToolbar i {
+      padding: 5px;
+      margin: 0 6px;
+      border-radius: 3px;
+    }
+    #annotationToolbar i:hover {
+      background-color: #555;
+    }
+    #annotationToolbar i.active {
+      background-color: #003d96;
+      border: 1px solid white;
+    }
+    #annotationToolbar i.lines.color1 { color: red    }
+    #annotationToolbar i.lines.color2 { color: cyan   }
+    #annotationToolbar i.lines.color3 { color: orange }
+    #annotationToolbar i.lines.color4 { color: green  }
+    #annotationToolbar i.shapes.color1 { color: red    }
+    #annotationToolbar i.shapes.color2 { color: cyan   }
+    #annotationToolbar i.shapes.color3 { color: orange }
+    #annotationToolbar i.shapes.color4 { color: green  }
+
+
 
 #bottom {
   display: -webkit-flex;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -7,6 +7,7 @@
   -webkit-flex-flow: column;
           flex-flow: column;
   min-width: 630px;
+  min-height: 675px;
 }
 
 #timerSection,
@@ -106,8 +107,8 @@
     display:         flex;
     -webkit-flex-flow: column;
             flex-flow: column;
-    -webkit-flex: 2;
-            flex: 2;
+    -webkit-flex: 1;
+            flex: 1;
     -webkit-order: 0;
             order: 0;
     min-width: 210px;
@@ -210,16 +211,24 @@
     display:         flex;
     -webkit-flex-flow: column;
             flex-flow: column;
-    -webkit-flex: 10;
-            flex: 10;
+    -webkit-flex: 4;
+            flex: 4;
     -webkit-order: 1;
             order: 1;
     min-width: 0px;
   }
+    #frame {
+      display: -webkit-flex;
+      display:         flex;
+      -webkit-flex-flow: row;
+              flex-flow: row;
+      -webkit-flex: 10;
+              flex: 10;
+    }
 
     #preview {
-      -webkit-flex: 1;
-              flex: 1;
+      -webkit-flex: 10;
+              flex: 10;
       overflow: auto;
       background: #eee;
       padding: 1em;
@@ -251,6 +260,8 @@
     }
 
     #statusbar {
+      -webkit-flex: 0.5;
+              flex: 0.5;
       height: 22px;
       line-height: 22px;
       text-transform: uppercase;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -111,12 +111,6 @@ pre code {
     max-height: 100%;
   }
 
-  /* explicit size so child elements can be sized from it */
-  .content {
-    height: 100%;
-    width: 100%;
-  }
-
   /* set up annotation overlays */
   .slide canvas.annotations {
     position: absolute;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -110,6 +110,22 @@ pre code {
     max-width: 100%;
     max-height: 100%;
   }
+
+  /* explicit size so child elements can be sized from it */
+  .content {
+    height: 100%;
+    width: 100%;
+  }
+
+  /* set up annotation overlays */
+  .slide canvas.annotations {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
 }
 
 /* plain (non-bullet) text */

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -86,13 +86,32 @@ function Annotate(params) {
 
     switch(this.tool) {
       case 'leftArrow':
-        var left  = new Path2D('m'+x+','+y+' 40,-40 0,20 50,0 0,40 -50,0 0,20 -40,-40 z');
-        this.context.fill(left);
+// IE doesn't understand Path2D
+//      var left  = new Path2D('m'+x+','+y+' 40,-40 0,20 50,0 0,40 -50,0 0,20 -40,-40 z');
+        this.context.beginPath();
+        this.context.moveTo(x, y);   x += 40;   y -= 40;
+        this.context.lineTo(x, y);              y += 20;
+        this.context.lineTo(x, y);   x += 50;
+        this.context.lineTo(x, y);              y += 40;
+        this.context.lineTo(x, y);   x -= 50;
+        this.context.lineTo(x, y);              y += 20;
+        this.context.lineTo(x, y);   x -= 40;   y -= 40;
+
+        this.context.fill();
         break;
 
       case 'rightArrow':
-        var right = new Path2D('m'+x+','+y+' -40,-40 0,20 -50,0 0,40 50,0 0,20 40,-40 z');
-        this.context.fill(right);
+//      var right = new Path2D('m'+x+','+y+' -40,-40 0,20 -50,0 0,40 50,0 0,20 40,-40 z');
+        this.context.beginPath();
+        this.context.moveTo(x, y);   x -= 40;   y -= 40;
+        this.context.lineTo(x, y);              y += 20;
+        this.context.lineTo(x, y);   x -= 50;
+        this.context.lineTo(x, y);              y += 40;
+        this.context.lineTo(x, y);   x += 50;
+        this.context.lineTo(x, y);              y += 20;
+        this.context.lineTo(x, y);   x += 40;   y -= 40;
+
+        this.context.fill();
         break;
 
       case 'highlight':

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -21,7 +21,7 @@ function Annotate(params) {
 
   this.setActiveCanvas = function(canvas) {
     // dereference so we can use raw DOM objects or jQuery collections
-    canvas = canvas[0] || canvas
+    canvas = canvas[0] || canvas;
     if (canvas.nodeName.toLowerCase() !== 'canvas' ) {
       throw new TypeError('Expected a DOM canvas element');
     }

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -82,12 +82,12 @@ function Annotate(params) {
 
     switch(this.tool) {
       case 'leftArrow':
-        var left  = new Path2D(`m${x},${y} 40,-40 0,20 50,0 0,40 -50,0 0,20 -40,-40 z`);
+        var left  = new Path2D('m'+x+','+y+' 40,-40 0,20 50,0 0,40 -50,0 0,20 -40,-40 z');
         this.context.fill(left);
         break;
 
       case 'rightArrow':
-        var right = new Path2D(`m${x},${y} -40,-40 0,20 -50,0 0,40 50,0 0,20 40,-40 z`);
+        var right = new Path2D('m'+x+','+y+' -40,-40 0,20 -50,0 0,40 50,0 0,20 40,-40 z');
         this.context.fill(right);
         break;
 

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -1,0 +1,255 @@
+function Annotate(params) {
+  if (!(this instanceof Annotate)) {
+    // the constructor was called without "new".
+    return new Annotate(params);;
+  }
+  params = typeof params !== 'undefined' ? params : {};
+
+  this.tool      = null;
+  this.context   = null;
+  this.callbacks = null;
+
+  // I'd like this to be styled, but this is enough for MVP
+  this.lineWidth          = params.lineWidth           || 5;
+  this.lineColor          = params.lineColor           || "#df4b26";
+  this.fillColor          = params.fillColor           || "#F49638";
+  this.highlightRadius    = params.highlightRadius     || 20;
+  this.highlightPeriod    = params.highlightPeriod     || 500;
+  this.highlightFillColor = params.highlightFillColor  || 'rgba(245, 213, 213, 0.5)';
+  this.highlightLineColor = params.highlightLineColor  || '#cc0000';
+  this.zoom               = params.zoom                || 1; // Can you just die already?
+
+  this.setActiveCanvas = function(canvas) {
+    // dereference so we can use raw DOM objects or jQuery collections
+    canvas = canvas[0] || canvas
+    if (canvas.nodeName.toLowerCase() !== 'canvas' ) {
+      throw new TypeError('Expected a DOM canvas element');
+    }
+    this.context = canvas.getContext("2d");
+
+    this.context.strokeStyle = this.lineColor;
+    this.context.fillStyle   = this.fillColor;
+    this.context.lineWidth   = this.lineWidth;
+    this.context.lineJoin    = "round";
+  }
+
+  this.erase = function() {
+    if ( this.callbacks && this.callbacks['erase'] ) {
+      try {
+        this.callbacks['erase']();
+      } catch (e) {
+        console.log('Erase callback failed. ' + e);
+      }
+    }
+
+    this.context.clearRect(0, 0, this.context.canvas.width, this.context.canvas.height);
+  }
+
+  this.draw = function(x, y) {
+    // undo the effects of the zoom
+    x = x / this.zoom;
+    y = y / this.zoom;
+
+    if ( this.callbacks && this.callbacks['draw'] ) {
+      try {
+        this.callbacks['draw'](x, y);
+      } catch (e) {
+        console.log('Draw callback failed. ' + e);
+      }
+    }
+
+    this.context.strokeStyle = this.lineColor;
+    this.context.lineTo(x, y);
+    this.context.stroke();
+  }
+
+  this.click = function(x, y) {
+    // undo the effects of the zoom
+    x = x / this.zoom;
+    y = y / this.zoom;
+
+    if ( this.callbacks && this.callbacks['click'] ) {
+      try {
+        this.callbacks['click'](x, y);
+      } catch (e) {
+        console.log('Click callback failed. ' + e);
+      }
+    }
+
+    this.context.fillStyle   = this.fillColor;
+    this.context.beginPath();
+    this.context.moveTo(x, y);
+
+    switch(this.tool) {
+      case 'leftArrow':
+        var left  = new Path2D(`m${x},${y} 40,-40 0,20 50,0 0,40 -50,0 0,20 -40,-40 z`);
+        this.context.fill(left);
+        break;
+
+      case 'rightArrow':
+        var right = new Path2D(`m${x},${y} -40,-40 0,20 -50,0 0,40 50,0 0,20 40,-40 z`);
+        this.context.fill(right);
+        break;
+
+      case 'highlight':
+        // save the current state of the canvas so we can restore it
+        var width   = this.context.canvas.width;
+        var height  = this.context.canvas.height;
+        var imgData = this.context.getImageData(0, 0, width, height);
+
+        var period = this.highlightPeriod;
+        var start  = null;
+
+        // Save the settings object so the animate() callback can get to it
+        var settings = this;
+
+        // can only accept a single timestamp argument
+        function animate(timestamp) {
+          if (!start) start = timestamp;
+          var progress = timestamp - start;
+
+          var linear = timestamp % period / period;   // ranges from 0 to 1
+          var easing = Math.sin(linear * Math.PI);    // simple easing to create some bounce
+          var radius = settings.highlightRadius * easing;
+
+          settings.context.clearRect(0, 0, width, height);
+          settings.context.beginPath();
+          settings.context.arc(x, y, radius, 0, Math.PI*2);
+
+          settings.context.fillStyle   = settings.highlightFillColor;
+          settings.context.strokeStyle = settings.highlightLineColor;
+
+          settings.context.fill();
+          settings.context.stroke();
+
+          if (progress < 1000) {
+            window.requestAnimationFrame(animate);
+          }
+          else {
+            // We're done animating, restore the canvas
+            settings.context.clearRect(0, 0, width, height);
+            settings.context.putImageData(imgData, 0, 0);
+            settings.context.strokeStyle = settings.lineColor;
+            settings.context.fillStyle   = settings.fillColor;
+          }
+        }
+        window.requestAnimationFrame(animate);
+        break;
+    }
+  }
+
+}
+
+
+// Allow us to attach the annotations to canvases via jquery
+// var annotations = new Annotate({lineColor: 'blue'});
+// $('#overlay').annotate(annotations);
+jQuery.fn.extend({
+  annotate: function (annotations) {
+    return this.each(function() {
+      if ( ! $(this).is( "canvas" ) ) {
+        throw new TypeError('The annotation functions only work on canvas elements');
+      }
+      if ( typeof annotations == 'undefined') {
+        // instantiate with defaults
+        annotations = new Annotate();
+      }
+      console.log('starting annotations');
+      var painting = false;
+
+      // the canvas cannot be css sized because reasons.
+      // Nor is it smart enough to understand how it fits into the styled page.
+      var height = $(this).parent().height();
+      var width  = $(this).parent().width();
+
+/*
+      annotations.top  = $(this).offset().top;
+      annotations.left = $(this).offset().left;
+*/
+
+      // We only want to do this the first time. It clears the canvas.
+      // Note that if the browser is resized, then the annotations are cleared.
+      if (this.height != height) {
+        this.height = height
+      }
+      if (this.width != width) {
+        this.width = width
+      }
+
+      annotations.setActiveCanvas(this);
+
+      // let the annotation overlay own mouse events.
+      // This means that clicking links or copying text will not work.
+      $(this).css('pointer-events', 'initial');
+
+      $(this).unbind( "mousedown" );
+      $(this).mousedown(function(e){
+        console.log(e);
+        painting = true;
+        annotations.click(e.offsetX, e.offsetY)
+      });
+
+      $(this).unbind( "mouseup" );
+      $(this).mouseup(function(e){
+        painting = false;
+      });
+
+      $(this).unbind( "mouseleave" );
+      $(this).mouseleave(function(e){
+        painting = false;
+      });
+
+      $(this).unbind( "mouseleave" );
+      $(this).mousemove(function(e){
+        if(painting){
+            annotations.draw(e.offsetX, e.offsetY);
+        }
+      });
+    });
+  },
+  stopAnnotation: function () {
+    return this.each(function() {
+      if ( ! $(this).is( "canvas" ) ) {
+        throw new TypeError('The annotation functions only work on canvas elements');
+      }
+      // Ignore pointer events again to make the overlay inactive.
+      $(this).css('pointer-events', 'none');
+
+      $(this).unbind( "mousedown" );
+      $(this).unbind( "mouseup" );
+      $(this).unbind( "mouseleave" );
+      $(this).unbind( "mouseleave" );
+    });
+  },
+  annotationListener: function (settings) {
+    return this.each(function() {
+      if ( ! $(this).is( "canvas" ) ) {
+        throw new TypeError('The annotation functions only work on canvas elements');
+      }
+      if ( typeof settings == 'undefined') {
+        // instantiate with defaults
+        annotations = Annotate();
+      }
+      console.log('starting annotation listener');
+
+      // the canvas cannot be css sized because reasons.
+      height = $(this).parent().height();
+      width  = $(this).parent().width();
+
+      annotations.top  = $(this).offset().top;
+      annotations.left = $(this).offset().left;
+
+      // We only want to do this the first time. It clears the canvas.
+      // Note that if the browser is resized, then the annotations are cleared.
+      if (this.height != height) {
+        this.height = height
+      }
+      if (this.width != width) {
+        this.width = width
+      }
+
+      annotations.setActiveCanvas(this);
+    });
+  }
+
+});

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -50,8 +50,9 @@ function Annotate(params) {
   this.draw = function(x, y) {
     if (this.tool == 'draw') {
       // undo the effects of the zoom
-      x = x / this.zoom;
-      y = y / this.zoom;
+      x = x * this.zoom;
+      y = y * this.zoom;
+
 
       if ( this.callbacks && this.callbacks['draw'] ) {
         try {
@@ -69,8 +70,8 @@ function Annotate(params) {
 
   this.click = function(x, y) {
     // undo the effects of the zoom
-    x = x / this.zoom;
-    y = y / this.zoom;
+    x = x * this.zoom;
+    y = y * this.zoom;
 
     if ( this.callbacks && this.callbacks['click'] ) {
       try {

--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -162,11 +162,6 @@ jQuery.fn.extend({
       var height = $(this).parent().height();
       var width  = $(this).parent().width();
 
-/*
-      annotations.top  = $(this).offset().top;
-      annotations.left = $(this).offset().left;
-*/
-
       // We only want to do this the first time. It clears the canvas.
       // Note that if the browser is resized, then the annotations are cleared.
       if (this.height != height) {
@@ -235,9 +230,6 @@ jQuery.fn.extend({
       // the canvas cannot be css sized because reasons.
       height = $(this).parent().height();
       width  = $(this).parent().width();
-
-      annotations.top  = $(this).offset().top;
-      annotations.left = $(this).offset().left;
 
       // We only want to do this the first time. It clears the canvas.
       // Note that if the browser is resized, then the annotations are cleared.

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -23,8 +23,8 @@ $(document).ready(function(){
   $("#stopTimer").click(function()  { stopTimer()   });
 
   /* zoom slide to match preview size, then set up resize handler. */
-  zoom();
-  $(window).resize(function() { zoom(); });
+  zoom(true);
+  $(window).resize(function() { zoom(true); });
 
   $('#statslink').click(function(e) {
     presenterPopupToggle('/stats', e);
@@ -32,16 +32,6 @@ $(document).ready(function(){
   $('#downloadslink').click(function(e) {
     presenterPopupToggle('/download', e);
   });
-
-  // Get the float value of the zoom. Because it's a string.
-  // Unless it's IE. Screw IE. Also, screw Firefox. It's supposed to be better than these shenanigans.
-  // IE returns a string percentage but we don't want to use it. Because it's lies. When we fix
-  // the presenter on IE so the viewport isn't all wack, we may have to revisit this.
-  // Firefox returns `undefined`.
-  var zoomLevel = Number( $('#preso').css('zoom') ) || 1;
-
-  // correct the zoom factor for the presenter
-  annotations.zoom = 1 / zoomLevel
 
   // Bind events for mobile viewing
   if( mobile() ) {

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -33,6 +33,16 @@ $(document).ready(function(){
     presenterPopupToggle('/download', e);
   });
 
+  // Get the float value of the zoom. Because it's a string.
+  // Unless it's IE. Screw IE. Also, screw Firefox. It's supposed to be better than these shenanigans.
+  // IE returns a string percentage but we don't want to use it. Because it's lies. When we fix
+  // the presenter on IE so the viewport isn't all wack, we may have to revisit this.
+  // Firefox returns `undefined`.
+  var zoomLevel = Number( $('#preso').css('zoom') ) || 1;
+
+  // correct the zoom factor for the presenter
+  annotations.zoom = 1 / zoomLevel
+
   // Bind events for mobile viewing
   if( mobile() ) {
     $('#preso').unbind('tap').unbind('swipeleft').unbind('swiperight');

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -9,7 +9,7 @@ section = 'notes'; // which section the presenter has chosen to view
 
 $(document).ready(function(){
   // set up the presenter modes
-  mode = { track: true, follow: true, update: true, slave: false, next: false, notes: false};
+  mode = { track: true, follow: true, update: true, slave: false, next: false, notes: false, annotations: false};
 
   // attempt to open another window for the presentation if the mode defaults
   // to enabling this. It does not by default, so this is likely a no-op.
@@ -54,13 +54,71 @@ $(document).ready(function(){
     });
   }
 
+  // Hide with js so jquery knows what display property to assign when showing
+  toggleAnnotations();
+
+  $('#annotationToolbar i.tool').click(function(e) {
+    var action = $(this).attr('data-action');
+
+    switch (action) {
+      case 'erase':
+        annotations.erase();
+        break;
+
+      default:
+        $('#annotationToolbar i.tool').removeClass('active');
+        $(this).addClass('active');
+        annotations.tool = action;
+        if (slaveWindow) slaveWindow.annotations.tool = action;
+        sendAnnotationConfig('tool', action);
+    }
+
+  });
+
+  $('#annotationToolbar i.lines').click(function(e) {
+    $('#annotationToolbar i.lines').removeClass('active');
+    $(this).addClass('active');
+    var color = $(this).css('color');
+
+    annotations.lineColor = color;
+    if (slaveWindow) slaveWindow.annotations.lineColor = color;
+    sendAnnotationConfig('lineColor', color);
+  });
+
+  $('#annotationToolbar i.shapes').click(function(e) {
+    $('#annotationToolbar i.shapes').removeClass('active');
+    $(this).addClass('active');
+    var color = $(this).css('color');
+
+    annotations.fillColor = color;
+    if (slaveWindow) slaveWindow.annotations.fillColor = color;
+    sendAnnotationConfig('fillColor', color);
+  });
+
   $('#remoteToggle').change( toggleFollower );
   $('#followerToggle').change( toggleUpdater );
+  $('#annotationsToggle').change( toggleAnnotations );
 
   setInterval(function() { updatePace() }, 1000);
 
   // Tell the showoff server that we're a presenter
   register();
+
+  annotations.callbacks = {
+    erase: function()    {
+      if (slaveWindow) slaveWindow.annotations.erase();
+      sendAnnotation('erase');
+    },
+    draw:  function(x, y) {
+      if (slaveWindow) slaveWindow.annotations.draw(x,y);
+      sendAnnotation('draw', x, y);
+    },
+    click: function(x,y) {
+      if (slaveWindow) slaveWindow.annotations.click(x,y);
+      sendAnnotation('click', x, y);
+    }
+  };
+
 });
 
 function presenterPopupToggle(page, event) {
@@ -443,7 +501,7 @@ function postSlide() {
       $(notesWindow.document.body).html(notes);
     }
 
-		var fileName = currentSlide.children().first().attr('ref');
+		var fileName = currentSlide.children('div').first().attr('ref');
 		$('#slideFile').text(fileName);
 
     $("#notes div.form.wrapper").each(function(e) {
@@ -632,12 +690,31 @@ function stopTimer() {
  ********************/
 function toggleFollower()
 {
-  mode.follow = $("#remoteToggle").attr("checked");
+  mode.follow = $("#remoteToggle").prop("checked");
   getPosition();
 }
 
 function toggleUpdater()
 {
-  mode.update = $("#followerToggle").attr("checked");
+  mode.update = $("#followerToggle").prop("checked");
   update();
+}
+
+/********************
+ Annotations
+ ********************/
+function toggleAnnotations()
+{
+  mode.annotations = $("#annotationsToggle").prop("checked");
+
+  if(mode.annotations) {
+    $('#annotationToolbar').show();
+    currentSlide.find('canvas.annotations').annotate(annotations);
+    $('canvas.annotations').show();
+  }
+  else {
+    $('#annotationToolbar').hide();
+    $('canvas.annotations').stopAnnotation();
+    $('canvas.annotations').hide();
+  }
 }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -71,9 +71,15 @@ function setupPreso(load_slides, prefix) {
   zoom();
   $(window).resize(function() {zoom();});
 
+  // because screw IE. That's why. Screw. IE.
+  var zoomLevel = parseFloat( $('#preso').css('zoom') );
+  if (zoomLevel > 1) {
+    zoomLevel = zoomLevel / 100.0;
+  }
+
   // yes, this is a global
   annotations = new Annotate({
-    zoom: $('#preso').css('zoom'),
+    zoom: zoomLevel
   });
 
   // Open up our control socket

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -897,7 +897,7 @@ function parseMessage(data) {
     }
   }
   catch(e) {
-    console.log("Not a presenter!");
+    console.log("Not a presenter! " + e);
   }
 
 }

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -263,6 +263,10 @@ function setupSideMenu() {
     closeMenu();
   });
 
+  $('#clearAnnotations').click(function() {
+    annotations.erase();
+  });
+
   $('#closeMenu, #sidebarExit').click(function() {
     closeMenu();
   });

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -71,16 +71,8 @@ function setupPreso(load_slides, prefix) {
   zoom();
   $(window).resize(function() {zoom();});
 
-  // because screw IE. That's why. Screw. IE.
-  var zoomLevel = parseFloat( $('#preso').css('zoom') );
-  if (zoomLevel > 1) {
-    zoomLevel = zoomLevel / 100.0;
-  }
-
   // yes, this is a global
-  annotations = new Annotate({
-    zoom: zoomLevel
-  });
+  annotations = new Annotate();
 
   // Open up our control socket
   if(mode.track) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -171,7 +171,7 @@ function initializePresentation(prefix) {
 	$("#preso").trigger("showoff:loaded");
 }
 
-function zoom() {
+function zoom(presenter=false) {
   var preso = $("#preso");
   var hSlide = parseFloat(preso.height());
   var wSlide = parseFloat(preso.width());
@@ -189,6 +189,21 @@ function zoom() {
   // Don't use standard transform to avoid modifying Chrome
   preso.css("-moz-transform", "scale(" + newZoom + ")");
   preso.css("-moz-transform-origin", "0 0 0");
+
+  // correct the zoom factor for the presenter
+  if (presenter) {
+    // We only want to zoom if the canvas is actually zoomed. Firefox and IE
+    // should *not* be zoomed, so we want to exclude them. We do that by reading
+    // back the zoom property. It will return a string percentage in IE, which
+    // won't parse as a number, and Firefox simply returns undefined.
+    // Because reasons.
+
+    // TODO: When we fix the presenter on IE so the viewport isn't all wack, we
+    // may have to revisit this.
+
+    var zoomLevel = Number( preso.css('zoom') ) || 1;
+    annotations.zoom = 1 / zoomLevel
+  }
 }
 
 function setupSideMenu() {

--- a/views/header.erb
+++ b/views/header.erb
@@ -23,6 +23,7 @@
 
   <script type="text/javascript" src="<%= @asset_path %>/js/coffee-script.js"></script>
 
+  <script type="text/javascript" src="<%= @asset_path %>/js/annotations.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js"></script>
 
   <% css_files.each do |css_file| %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -63,6 +63,8 @@
         <div id="editSlide" class="buttonWrapper">Edit Current Slide</div>
         <% end %>
         <hr>
+        <div id="clearAnnotations" class="buttonWrapper"><i class="fa fa-eraser"></i> Clear Annotations</div>
+        <hr>
     <% end %>
 
     <div id="closeMenu" class="buttonWrapper"><i class="fa fa-close"></i> Close</div>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -74,9 +74,29 @@
       <div id="navigation" class="submenu"></div>
     </div>
     <div id="presenter">
-      <div id="preview">
-        <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
-        <div id="preso">loading presentation...</div>
+      <div id="frame">
+        <div id="preview">
+          <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
+          <div id="preso">loading presentation...</div>
+        </div>
+        <div id="annotationToolbar">
+          <label>Tools</label>
+            <i class="fa fa-pencil tool default active" data-action="draw" aria-hidden="true"></i>
+            <i class="fa fa-arrow-right tool"  data-action="rightArrow" aria-hidden="true"></i>
+            <i class="fa fa-arrow-left tool"  data-action="leftArrow" aria-hidden="true"></i>
+            <i class="fa fa-bullseye tool" data-action="highlight" aria-hidden="true"></i>
+            <i class="fa fa-eraser tool"  data-action="erase" aria-hidden="true"></i>
+          <label>Lines</label>
+            <i class="fa fa-square-o lines color1 active" aria-hidden="true"></i>
+            <i class="fa fa-square-o lines color2" aria-hidden="true"></i>
+            <i class="fa fa-square-o lines color3" aria-hidden="true"></i>
+            <i class="fa fa-square-o lines color4" aria-hidden="true"></i>
+          <label>Shapes</label>
+            <i class="fa fa-square shapes color1" aria-hidden="true"></i>
+            <i class="fa fa-square shapes color2" aria-hidden="true"></i>
+            <i class="fa fa-square shapes color3 active" aria-hidden="true"></i>
+            <i class="fa fa-square shapes color4" aria-hidden="true"></i>
+        </div>
       </div>
       <div id="statusbar">
         <span id="progress">
@@ -94,24 +114,6 @@
         </span>
 
       </div>
-    </div>
-    <div id="annotationToolbar">
-      <label>Tools</label>
-        <i class="fa fa-pencil tool default active" data-action="draw" aria-hidden="true"></i>
-        <i class="fa fa-arrow-right tool"  data-action="rightArrow" aria-hidden="true"></i>
-        <i class="fa fa-arrow-left tool"  data-action="leftArrow" aria-hidden="true"></i>
-        <i class="fa fa-bullseye tool" data-action="highlight" aria-hidden="true"></i>
-        <i class="fa fa-eraser tool"  data-action="erase" aria-hidden="true"></i>
-      <label>Lines</label>
-        <i class="fa fa-square-o lines color1 active" aria-hidden="true"></i>
-        <i class="fa fa-square-o lines color2" aria-hidden="true"></i>
-        <i class="fa fa-square-o lines color3" aria-hidden="true"></i>
-        <i class="fa fa-square-o lines color4" aria-hidden="true"></i>
-      <label>Shapes</label>
-        <i class="fa fa-square shapes color1" aria-hidden="true"></i>
-        <i class="fa fa-square shapes color2" aria-hidden="true"></i>
-        <i class="fa fa-square shapes color3 active" aria-hidden="true"></i>
-        <i class="fa fa-square shapes color4" aria-hidden="true"></i>
     </div>
   </div>
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -89,7 +89,29 @@
         <span id="enableFollower" title="Send slide change notifications.">
           <label for="followerToggle">Update Follower</label><input type="checkbox" id="followerToggle" checked />
         </span>
+        <span id="enableAnnotations" title="Enable the annotation system.">
+          <label for="annotationsToggle">Annotations</label><input type="checkbox" id="annotationsToggle" />
+        </span>
+
       </div>
+    </div>
+    <div id="annotationToolbar">
+      <label>Tools</label>
+        <i class="fa fa-pencil tool default active" data-action="draw" aria-hidden="true"></i>
+        <i class="fa fa-arrow-right tool"  data-action="rightArrow" aria-hidden="true"></i>
+        <i class="fa fa-arrow-left tool"  data-action="leftArrow" aria-hidden="true"></i>
+        <i class="fa fa-bullseye tool" data-action="highlight" aria-hidden="true"></i>
+        <i class="fa fa-eraser tool"  data-action="erase" aria-hidden="true"></i>
+      <label>Lines</label>
+        <i class="fa fa-square-o lines color1 active" aria-hidden="true"></i>
+        <i class="fa fa-square-o lines color2" aria-hidden="true"></i>
+        <i class="fa fa-square-o lines color3" aria-hidden="true"></i>
+        <i class="fa fa-square-o lines color4" aria-hidden="true"></i>
+      <label>Shapes</label>
+        <i class="fa fa-square shapes color1" aria-hidden="true"></i>
+        <i class="fa fa-square shapes color2" aria-hidden="true"></i>
+        <i class="fa fa-square shapes color3 active" aria-hidden="true"></i>
+        <i class="fa fa-square shapes color4" aria-hidden="true"></i>
     </div>
   </div>
 


### PR DESCRIPTION
Kari was away for the weekend, so I decided to hack up something fun.
This is not quite ready for merge, but it's rather usable in its current
state. It allows the instructor to draw on the slide from the presenter
view. The annotations are replicated on the display view on the
projector and each of the audience member's browsers. Annotations are
attached to the slide rather than just overlaying the whole display.
This means that switching slides will switch annotations too.
- [x] It's untested on IE.
- [x] It boogers up the section pages.
- [x] The scaling between different views is a tiny bit off. (damn you, zoom!)
- [x] It could use a little minor polishing.
  - [x] Dragging when adding a shape draws and it should not
  - [x] The highlighting animation clears the screen
  - [x] The placement of the annotations bar is slightly off (it pushes the status bar over)

![screen shot 2016-08-01 at 10 41 51 pm](https://cloud.githubusercontent.com/assets/1392917/17318198/2c11e644-5839-11e6-82e4-653a4f556af4.png)

Fixes #505, #506
