### PR TITLE
Make follow/update modes work again.

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -632,12 +632,12 @@ function stopTimer() {
  ********************/
 function toggleFollower()
 {
-  mode.follow = $("#remoteToggle").attr("checked");
+  mode.follow = $("#remoteToggle").prop("checked");
   getPosition();
 }
 
 function toggleUpdater()
 {
-  mode.update = $("#followerToggle").attr("checked");
+  mode.update = $("#followerToggle").prop("checked");
   update();
 }


### PR DESCRIPTION
When we updated jQuery, we missed that the semantics of the `.attr()`
method changed. This corrects the method used to retrieve the checkbox
state of the two toggles.

Fixes #544 
