### PR TITLE
Don't scroll the menu sideways

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -202,7 +202,8 @@
 
     .submenu {
       display: block;
-      overflow: auto;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
 
   #presenter {


### PR DESCRIPTION
Prior to this, with a long section title, the sidebar menu would scroll
sideways in a most disconcerting way.
