### PR TITLE
Less whitespace in nested code-in-tables

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -20,6 +20,11 @@ pre {
   padding: .25em;
 }
 
+/* when code blocks are embedded in a table, we don't need giant whitespace */
+table pre {
+  margin: 0;
+}
+
 /* applies to inline code only */
 code {
   padding: 2px 4px;


### PR DESCRIPTION
When you're putting code inside a table, you won't want giant whitespace
surrounding the code blocks. This removes some of the doubled up
padding.
