### PR TITLE
Enhances serving from git functionality

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -176,7 +176,13 @@ command :serve do |c|
   c.flag [:f, :file, :pres_file]
 
   c.desc 'Git URL to a repository containing the presentation'
-  c.flag [:u, :url]
+  c.flag [:u, :url, :git_url]
+
+  c.desc 'Branch of the git repository to use'
+  c.flag [:git_branch]
+
+  c.desc 'Path of the presentation within the git repository'
+  c.flag [:git_path]
 
   c.action do |global_options,options,args|
 
@@ -220,7 +226,7 @@ To run it from presenter view, go to: [ #{url}/presenter ]
 "
 
     if options[:url]
-      ShowOffUtils.clone(options[:url], options[:verbose]) do
+      ShowOffUtils.clone(options[:git_url], options[:git_branch], options[:git_path]) do
         ShowOff.run!(options) do |server|
           if options[:ssl]
             server.ssl         = true

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -205,13 +205,17 @@ class ShowOffUtils
   end
 
   # clone a repo url, then run a provided block
-  def self.clone(url, verbose=false)
+  def self.clone(url, branch=nil, path=nil)
     require 'tmpdir'
     Dir.mktmpdir do |dir|
-      Dir.chdir dir do
-        puts "Cloning presentation repository to #{dir}..." if verbose
-        system('git', 'clone', '--depth', '1', url, '.')
+      if branch
+        system('git', 'clone', '-b', branch, '--single-branch', '--depth', '1', url, dir)
+      else
+        system('git', 'clone', '--depth', '1', url, dir)
+      end
 
+      dir = File.join(dir, path) if path
+      Dir.chdir dir do
         yield if block_given?
       end
     end


### PR DESCRIPTION
Adds some new flags, so now you can

```
showoff serve --git_url <repo> --git_branch devel --git_path 'path/to/preso'
```

This will clone your repository, check out the `devel` branch, and cd into
`path/to/preso` within the repository. When combined with a pull request
workflow (present directly from the PR branch), or with the online edit button,
drastic efficiency improvements can be achieved.

Fixes #548
