### PR TITLE
Don't limit rule just to toplevel lists

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -188,7 +188,7 @@ pre code {
 }
 
 /* ironically, normal lists have bullets and 'bullets' lists don't */
-.bullets > ul {
+.bullets ul {
   list-style: none;
   padding-left: 0px;
 }


### PR DESCRIPTION
Before this, the centered lists had weird and ugly bullets way off to
the left.

Fixes #522
