### PR TITLE
Use the full width of the menubar

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -485,6 +485,9 @@ img#disconnected {
 }
 
 .navItem {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   padding: .5em 1.5em;
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -337,10 +337,11 @@ function setupMenu() {
     // look for first header to use as a title
     if (headers.length > 0) {
       slideTitle = headers.first().text();
+
     } else {
-      // if no header, look at content
+      // if no header, look at the first non-empty line of content
       content    = $(slide).find(".content");
-      slideTitle = content.text().substr(0, 20).trim();
+      slideTitle = content.text().split("\n").filter(Boolean)[0].trim();
 
       // if no content (like photo only) fall back to slide name
       if (slideTitle == "") {


### PR DESCRIPTION
This will create a full width title and use CSS to ellipsize when it's
too long to fit. Some browsers will provide a tooltip with the full
title as well.

Tested in Safari, Chrome, Firefox.

Fixes #542 
