### PR TITLE
Catch error when a slide has no content

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -341,12 +341,15 @@ function setupMenu() {
     } else {
       // if no header, look at the first non-empty line of content
       content    = $(slide).find(".content");
-      slideTitle = content.text().split("\n").filter(Boolean)[0].trim();
+      slideTitle = content.text().split("\n").filter(Boolean)[0] || ''; // split() gives us an empty array when there's no content.
 
       // if no content (like photo only) fall back to slide name
       if (slideTitle == "") {
         slideTitle = content.attr('ref').split('/').pop();
       }
+
+      // just in case we've got any extra whitespace around.
+      slideTitle = slideTitle.trim();
     }
 
     var navLink = $("<a>")


### PR DESCRIPTION
.split() gives us an empty array when there's no content, so we can't
call .trim() on a null. Instead, return an empty string and just make
sure we trim the title before we pass it on.
