### PR TITLE
IE is ancient.

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -171,7 +171,7 @@ function initializePresentation(prefix) {
 	$("#preso").trigger("showoff:loaded");
 }
 
-function zoom(presenter=false) {
+function zoom(presenter) {
   var preso = $("#preso");
   var hSlide = parseFloat(preso.height());
   var wSlide = parseFloat(preso.width());


### PR DESCRIPTION
Stands to reason that I caught this right after shipping, too.
This breaks the presentation completely on IE because the js doesn't
parse properly.
