### PR TITLE
Make zoom work in Chrome

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -278,7 +278,9 @@ function openNotes()
   if (mode.notes) {
     try {
       if(notesWindow == null || typeof(notesWindow) == 'undefined' || notesWindow.closed){
-          notesWindow = window.open('', '', 'width=350,height=450');
+          // yes, the explicit address is needed. Because Chrome.
+          notesWindow = window.open('about:blank', '', 'width=350,height=450');
+          notesWindow.document.title = "Showoff Notes";
           postSlide();
       }
       $('#notesWindow').addClass('enabled');


### PR DESCRIPTION
So even though spec says that opening a blank address loads
`about:blank` by default, Chrome does something fucky and gets into a
state where text won't zoom at all. If we pass the address in explicitly
then it all works properly.

Fixes #536
