### PR TITLE
This adds several preview widgets to the presenter

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -226,7 +226,6 @@
               flex-flow: row;
       -webkit-flex: 10;
               flex: 10;
-      max-height: 95%;  /* dear Firefox; what's the point of flex-box if we still have to do this crap? */
     }
 
     #preview {
@@ -264,6 +263,9 @@
       -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
       -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
       box-shadow:0 0 25px rgba(0,0,0,0.35);
+    }
+    body.no-zoom #preso {
+      position: absolute;
     }
 
     #statusbar {

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -206,6 +206,22 @@
       overflow-x: hidden;
       overflow-y: auto;
     }
+    #navigationHover {
+      display: none;
+      position: absolute;
+      overflow: hidden;
+      z-index: 99999;
+      width: 200px;
+      height: 150px;
+      background-color: white;
+      border: 1px solid #4D4F53;
+      margin: 0px;
+      border-radius: 3px;
+      box-shadow: 3px 3px 5px #ccc;
+    }
+      #navigationHover * {
+        zoom: 0.2;
+      }
 
   #presenter {
     display: -webkit-flex;
@@ -229,13 +245,40 @@
       max-height: 95%;  /* dear Firefox; what's the point of flex-box if we still have to do this crap? */
     }
 
+
     #preview {
+      position: relative;
       -webkit-flex: 10;
               flex: 10;
       overflow: auto;
       background: #eee;
       padding: 1em;
     }
+      #preview.thumbs {
+        padding-top: 100px;
+      }
+      #preview .thumb {
+        display: none;
+        position: absolute;
+        overflow: hidden;
+        height: 150px;
+        width: 200px;
+        top: 0;
+        background-color: white;
+        border-bottom: 2px solid #ccc;
+      }
+        #preview .thumb * {
+          zoom: 0.1;
+        }
+        #prevSlide.thumb {
+          left: 0;
+          border-right: 2px solid #ccc;
+        }
+        #nextSlide.thumb {
+          right: 0;
+          border-left: 2px solid #ccc;
+        }
+
       #preview input[type=button].display {
         display: inline;
       }
@@ -247,8 +290,12 @@
         font-weight: 900;
       }
 
-      #disconnected {
+      #preview img#disconnected {
         margin: 0.5em 1em;
+        float: none;
+        position: absolute;
+        bottom: 0;
+        left: 0;
       }
 
       #preview .incremental.hidden {
@@ -285,7 +332,8 @@
       }
       #enableFollower,
       #enableRemote,
-      #enableAnnotations {
+      #enableAnnotations,
+      #enableThumbs {
         float: right;
         margin: 1px;
         padding: 0.1em;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -258,7 +258,7 @@
       position: relative;
       -webkit-flex: 10;
               flex: 10;
-      overflow: auto;
+      overflow: hidden;
       background: #eee;
       padding: 1em;
     }
@@ -294,6 +294,20 @@
           margin-right: auto;
           left: 0;
           right: 0;
+        }
+        #preview.thumbs #preso.firefox {
+          position: relative;
+        }
+        #preview .thumb.firefox {
+          height: 300px;
+          width: 400px;
+          -moz-transform: scale(.5);
+        }
+        #prevSlide.thumb.firefox {
+          -moz-transform-origin: top left;
+        }
+        #nextSlide.thumb.firefox {
+          -moz-transform-origin: top right;
         }
 
         /* allow us to actually see images! */

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -219,8 +219,16 @@
       border-radius: 3px;
       box-shadow: 3px 3px 5px #ccc;
     }
-      #navigationHover * {
+      #navigationHover .content {
         zoom: 0.2;
+        -moz-transform: scale(0.5);
+        -moz-transform-origin: 0 0;
+      }
+      /* ugh, firefox. */
+      @-moz-document url-prefix() {
+        #navigationHover .content {
+          width: 200%;
+        }
       }
 
   #presenter {

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -279,6 +279,13 @@
           border-left: 2px solid #ccc;
         }
 
+        /* allow us to actually see images! */
+        #navigationHover img,
+        .thumb img {
+          width: 100%;
+          height: 100%;
+        }
+
       #preview input[type=button].display {
         display: inline;
       }

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -27,12 +27,15 @@
   color: #fff;
 }
 
-  #topbar a {
+  #topbar a,
+  #topbar select {
     text-decoration: none;
     color: #fff;
+    background: #222222;
   }
 
-  #topbar a:hover{
+  #topbar a:hover,
+  #topbar select:hover {
     background-color: #555;
   }
 
@@ -260,6 +263,8 @@
       background: #eee;
       padding: 1em;
     }
+
+    /* thumbnails layout */
       #preview.thumbs {
         padding-top: 100px;
       }
@@ -317,6 +322,28 @@
           height: 100%;
         }
 
+    /* beside layout */
+      #preview.beside .thumb {
+        display: none;
+        position: absolute;
+        overflow: hidden;
+        width: 34%;
+        top: 1em;
+      }
+        #preview.beside .thumb * {
+          zoom: 0.1;
+        }
+        #nextSlide.beside {
+          right: 1em;
+        }
+
+        #preview.beside #preso {
+          position: absolute;
+          left: 1em;
+          width: 64%;
+        }
+
+
       #preview input[type=button].display {
         display: inline;
       }
@@ -370,8 +397,7 @@
       }
       #enableFollower,
       #enableRemote,
-      #enableAnnotations,
-      #enableThumbs {
+      #enableAnnotations {
         float: right;
         margin: 1px;
         padding: 0.1em;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -225,10 +225,8 @@
         -moz-transform-origin: 0 0;
       }
       /* ugh, firefox. */
-      @-moz-document url-prefix() {
-        #navigationHover .content {
-          width: 200%;
-        }
+      body.no-zoom #navigationHover .content {
+        width: 200%;
       }
 
   #presenter {
@@ -295,18 +293,20 @@
           left: 0;
           right: 0;
         }
-        #preview.thumbs #preso.firefox {
+
+        /* firefoxy fixes */
+        body.no-zoom #preview.thumbs #preso {
           position: relative;
         }
-        #preview .thumb.firefox {
+        body.no-zoom #preview .thumb {
           height: 300px;
           width: 400px;
           -moz-transform: scale(.5);
         }
-        #prevSlide.thumb.firefox {
+        body.no-zoom #prevSlide.thumb {
           -moz-transform-origin: top left;
         }
-        #nextSlide.thumb.firefox {
+        body.no-zoom #nextSlide.thumb {
           -moz-transform-origin: top right;
         }
 

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -279,6 +279,15 @@
           border-left: 2px solid #ccc;
         }
 
+        #preview.thumbs #preso {
+          position: absolute;
+          bottom: 1em;
+          margin-left: auto;
+          margin-right: auto;
+          left: 0;
+          right: 0;
+        }
+
         /* allow us to actually see images! */
         #navigationHover img,
         .thumb img {

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -315,9 +315,6 @@
         }
 
         /* firefoxy fixes */
-        body.no-zoom #preview.thumbs #preso {
-          position: relative;
-        }
         body.no-zoom #preview .thumb {
           height: 300px;
           width: 400px;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -75,7 +75,8 @@
     margin: 0 0.5em;
   }
 
-#presenterPopup {
+#presenterPopup,
+#nextWindowConfirmation {
   display: none;
   position: absolute;
   z-index: 2147483647;
@@ -91,9 +92,24 @@
   overflow: auto;
 }
 
-  #presenterPopup a {
+  #presenterPopup a,
+  #nextWindowConfirmation a {
     color: #ffffff;
   }
+
+#nextWindowConfirmation {
+  right: 0.25em;
+  left: auto;
+  width: 14em;
+}
+  #nextWindowConfirmation p {
+    margin: 0.25em;
+  }
+  #nextWindowConfirmation input {
+    float: right;
+    margin: 0.25em;
+  }
+
 
 #center {
   display: -webkit-flex;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -324,6 +324,12 @@
           width: 400px;
           -moz-transform: scale(.5);
         }
+        body.no-zoom #preview.beside .thumb {
+          width: 34%;
+          -moz-transform: none;
+          font-size: 0.5em;
+        }
+
         body.no-zoom #prevSlide.thumb {
           -moz-transform-origin: top left;
         }
@@ -357,6 +363,16 @@
           position: absolute;
           left: 1em;
           width: 64%;
+        }
+
+        /* firefoxy fixes */
+        body.no-zoom #preview.beside #preso {
+          width: 100%;
+        }
+        body.no-zoom #preview.beside .thumb {
+          width: 34%;
+          -moz-transform: none;
+          font-size: 0.5em;
         }
 
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -69,10 +69,6 @@ pre code {
     background-size: cover;
     position: relative;
   }
-  /* When we scale on Firefox, keep it centered */
-  #preso {
-    -moz-transform-origin: 0 0;
-  }
 
   .slide {
     font-size: 1.5em;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -67,6 +67,7 @@ pre code {
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;
+    position: relative;
   }
 
   .slide {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -68,6 +68,10 @@ pre code {
     background-position: center;
     background-size: cover;
   }
+  /* When we scale on Firefox, keep it centered */
+  #preso {
+    -moz-transform-origin: 0 0;
+  }
 
   .slide {
     font-size: 1.5em;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -333,7 +333,7 @@ function blankStyledWindow(title, dimensions, zoom) {
       $(newWindow.document.head).append(style);
 
       // ugh; Firefox is the new IE.
-      if (navigator.userAgent.match(/firefox/i)) {
+      if (! cssPropertySupported('zoom')) {
         $(newWindow.document.head).append('<style type="text/css">.content { width: 200%; }</style>');
       }
     }
@@ -786,11 +786,6 @@ function toggleThumbs()
   mode.thumbs = $("#thumbsToggle").prop("checked");
 
   if(mode.thumbs) {
-    // A solution I only arrive at with great self-loathing.
-    if(navigator.userAgent.indexOf("Firefox") != -1) {
-      $('#preso').addClass('firefox');
-      $('#preview .thumb').addClass('firefox');
-    }
     $('#preview').addClass('thumbs');
     $('#preview .thumb').show();
   }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -32,7 +32,7 @@ $(document).ready(function(){
   $('#downloadslink').click(function(e) {
     presenterPopupToggle('/download', e);
   });
-  $('#layoutSelector').click(function(e) {
+  $('#layoutSelector').change(function(e) {
     chooseLayout(e.target.value);
   });
 
@@ -756,17 +756,34 @@ function toggleAnnotations()
   }
 }
 
+function openNext() {
+  $("#nextWindowConfirmation").slideUp(125);
+  try {
+    if(windowIsClosed(nextWindow)){
+      nextWindow = blankStyledWindow("Next Slide Preview", 'width=320,height=300', 0.25);
+
+      // call back and update the parent presenter if the window is closed
+      nextWindow.window.onunload = function(e) {
+        nextWindow.opener.chooseLayout('default');
+      };
+
+      postSlide();
+    }
+  }
+  catch(e) {
+    console.log(e);
+    console.log('Failed to open or connect next window. Popup blocker?');
+  }
+}
 
 /********************
  Layout selection incorporates previews and the old next window
  ********************/
 function chooseLayout(layout)
 {
-  if (layout == mode.layout) {
-    return false;
-  }
   // in case we're being called externally, make the UI match
-  $('#layoutSelector').val(layout)
+  $('#layoutSelector').val(layout);
+  $("#nextWindowConfirmation").slideUp(125);
   console.log("Setting layout to " + layout);
 
   // what we are switching *from*
@@ -817,22 +834,7 @@ function chooseLayout(layout)
       break;
 
     case 'floating':
-      try {
-        if(windowIsClosed(nextWindow)){
-          nextWindow = blankStyledWindow("Next Slide Preview", 'width=320,height=300', 0.25);
-
-          // call back and update the parent presenter if the window is closed
-          nextWindow.window.onunload = function(e) {
-            nextWindow.opener.chooseLayout('default');
-          };
-
-          postSlide();
-        }
-      }
-      catch(e) {
-        console.log(e);
-        console.log('Failed to open or connect next window. Popup blocker?');
-      }
+      $("#nextWindowConfirmation").slideDown(125);
       break;
 
     default:

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -774,5 +774,5 @@ function toggleThumbs()
     $('#preview').removeClass('thumbs');
     $('#preview .thumb').hide();
   }
-  zoom();
+  zoom(true);
 }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -255,15 +255,8 @@ function openNext()
   if (mode.next) {
     try {
       if(nextWindow == null || typeof(nextWindow) == 'undefined' || nextWindow.closed){
-          nextWindow = window.open('about:blank','','width=320,height=300');
-          nextWindow.document.title = "Next Slide Preview";
-
-          $('<base/>',{ "href": window.location.origin }).appendTo($(nextWindow.document.head));
-          $('link[rel="stylesheet"]').each(function() {
-            $(nextWindow.document.head).append($(this).clone());
-          });
-          $(nextWindow.document.head).append('<style type="text/css">.content { zoom: 0.25; }</style>');
-          postSlide();
+        nextWindow = blankStyledWindow("Next Slide Preview", 'width=320,height=300', 0.25);
+        postSlide();
       }
 
       $('#nextWindow').addClass('enabled');
@@ -294,10 +287,8 @@ function openNotes()
   if (mode.notes) {
     try {
       if(notesWindow == null || typeof(notesWindow) == 'undefined' || notesWindow.closed){
-          // yes, the explicit address is needed. Because Chrome.
-          notesWindow = window.open('about:blank', '', 'width=350,height=450');
-          notesWindow.document.title = "Showoff Notes";
-          postSlide();
+        notesWindow = blankStyledWindow("Showoff Notes", 'width=350,height=450', 0.5);
+        postSlide();
       }
       $('#notesWindow').addClass('enabled');
     }
@@ -314,6 +305,25 @@ function openNotes()
       console.log('Notes window failed to close properly.');
     }
   }
+}
+
+function blankStyledWindow(title, dimensions, zoom) {
+  // yes, the explicit address is needed. Because Chrome.
+  newWindow = window.open('about:blank','', dimensions);
+  newWindow.document.title = title;
+
+  $('<base/>',{ "href": window.location.origin }).appendTo($(newWindow.document.head));
+  $('link[rel="stylesheet"]').each(function() {
+    $(newWindow.document.head).append($(this).clone());
+  });
+  $(newWindow.document.head).append('<style type="text/css">body { margin: 0.5em; }</style>');
+
+  if(zoom) {
+    // TODO: This will need to be updated to not be terrible on Firefox
+    $(newWindow.document.head).append('<style type="text/css">.content { zoom: '+zoom+'; }</style>');
+  }
+
+  return newWindow;
 }
 
 function printSlides()

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -786,6 +786,11 @@ function toggleThumbs()
   mode.thumbs = $("#thumbsToggle").prop("checked");
 
   if(mode.thumbs) {
+    // A solution I only arrive at with great self-loathing.
+    if(navigator.userAgent.indexOf("Firefox") != -1) {
+      $('#preso').addClass('firefox');
+      $('#preview .thumb').addClass('firefox');
+    }
     $('#preview').addClass('thumbs');
     $('#preview .thumb').show();
   }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -791,6 +791,10 @@ function chooseLayout(layout)
   $("#nextWindowConfirmation").slideUp(125);
   console.log("Setting layout to " + layout);
 
+  // change focus so we don't inadvertently change layout again by changing slides
+  $("#preview").focus();
+  $("#layoutSelector").blur();
+
   // what we are switching *from*
   switch(mode.layout) {
     case 'thumbs':

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -310,18 +310,37 @@ function openNotes()
 function blankStyledWindow(title, dimensions, zoom) {
   // yes, the explicit address is needed. Because Chrome.
   newWindow = window.open('about:blank','', dimensions);
-  newWindow.document.title = title;
 
-  $('<base/>',{ "href": window.location.origin }).appendTo($(newWindow.document.head));
-  $('link[rel="stylesheet"]').each(function() {
-    $(newWindow.document.head).append($(this).clone());
-  });
-  $(newWindow.document.head).append('<style type="text/css">body { margin: 0.5em; }</style>');
+//  $(newWindow.document).ready(function() {
+//  setTimeout(function() {
+  var wtfFirefox = function() {
+    newWindow.document.title = title;
 
-  if(zoom) {
-    // TODO: This will need to be updated to not be terrible on Firefox
-    $(newWindow.document.head).append('<style type="text/css">.content { zoom: '+zoom+'; }</style>');
-  }
+    $('<base/>',{ "href": window.location.origin }).appendTo($(newWindow.document.head));
+    $('link[rel="stylesheet"]').each(function() {
+      $(newWindow.document.head).append($(this).clone());
+    });
+    $(newWindow.document.head).append('<style type="text/css">body { margin: 0.5em; }</style>');
+
+    if(zoom) {
+      // TODO: This will need to be updated to not be terrible on Firefox
+      var style = '<style type="text/css">            \
+            body { overflow: hidden; }                \
+            .content { zoom: '+zoom+';                \
+            -moz-transform: scale(' + zoom * 2 + ');  \
+            -moz-transform-origin: 0 0; }</style>';
+
+      $(newWindow.document.head).append(style);
+
+      // ugh; Firefox is the new IE.
+      if (navigator.userAgent.match(/firefox/i)) {
+        $(newWindow.document.head).append('<style type="text/css">.content { width: 200%; }</style>');
+      }
+    }
+  };
+
+  newWindow.window.onload = wtfFirefox;
+  $(newWindow.document).ready(wtfFirefox);
 
   return newWindow;
 }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -161,7 +161,7 @@ function presenterPopupToggle(page, event) {
 
       content.attr('id', page.substring(1, page.length));
       content.append(link);
-      /* use .sibliings() because of how jquery formats $(data) */
+      /* use .siblings() because of how jquery formats $(data) */
       content.append($(data).siblings('#wrapper').html());
       popup.append(content);
 
@@ -251,7 +251,6 @@ function openSlave()
 
 function nextSlideNum(url) {
   // Some fudging because the first slide is slide[0] but numbered 1 in the URL
-  console.log(typeof(url));
   var snum;
   if (typeof(url) == 'undefined') { snum = currentSlideFromParams()+1; }
   else { snum = currentSlideFromParams()+2; }
@@ -528,6 +527,7 @@ function postSlide() {
 
     $('#nextSlide').html(nextSlide);
     $('#prevSlide').html(prevSlide);
+
     if (windowIsOpen(nextWindow)) {
       $(nextWindow.document.body).html(nextSlide);
     }
@@ -762,12 +762,17 @@ function openNext() {
     if(windowIsClosed(nextWindow)){
       nextWindow = blankStyledWindow("Next Slide Preview", 'width=320,height=300', 0.25);
 
-      // call back and update the parent presenter if the window is closed
-      nextWindow.window.onunload = function(e) {
-        nextWindow.opener.chooseLayout('default');
-      };
+      // Firefox doesn't load content properly unless we delay it slightly. Yay for race conditions.
+//      nextWindow.addEventListener("unload", function() {
+      window.setTimeout(function() {
+        // call back and update the parent presenter if the window is closed
+        nextWindow.onunload = function(e) {
+          nextWindow.opener.chooseLayout('default');
+        };
 
-      postSlide();
+        postSlide();
+      }, 500);
+
     }
   }
   catch(e) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -188,26 +188,23 @@ function zoom(presenter) {
 
   // // Firefox doesn't support zoom.
   if($("body").hasClass("no-zoom")) {
-    var hPos = 0;
-    var wPos = 0;
-
-    // Because Firefox's transform doesn't scale up very well
-    newZoom = newZoom > 1 ? 1 : newZoom - .04;
 
     // why so terrible?
     if($("#preview").hasClass("beside")) {
       // match the 65/35 split in the stylesheet
       wBody  *= 0.64;
       newZoom = Math.min(hBody/hSlide, wBody/wSlide);
-    } else if(presenter) { // We only need to offset from center if we're wrapped in the presenter view.
-
-      // Calculate the new offsets to roughly center the preview again
-      hPos = (hBody - (hSlide * newZoom)) / 2;
-      wPos = (wBody - (wSlide * newZoom)) / 2;
     }
 
-    // Don't use standard transform to avoid modifying Chrome
-    preso.css("-moz-transform", "scale(" + newZoom + ") translateX(" + wPos + "px) translateY(" + hPos + "px)");
+    // Calculate margins to center the thing *before* scaling
+    var hMargin = (hBody - hSlide) /2;
+    var wMargin = (wBody - wSlide) /2;
+
+    // Because Firefox's transform doesn't scale up very well
+    newZoom = newZoom > 1 ? 1 : newZoom - .04;
+
+    preso.css("margin", hMargin + "px " + wMargin + "px");
+    preso.css("transform", "scale(" + newZoom + ")");
   }
 
   // correct the zoom factor for the presenter

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -182,20 +182,33 @@ function zoom(presenter) {
 
   var newZoom = Math.min(hBody/hSlide, wBody/wSlide);
 
-  // Because Firefox's transform doesn't scale up very well
-  newZoom = newZoom > 1 ? 1 : newZoom - .04;
-
-  // Calculate the new offsets to roughly center the preview again
-  var hPos = (hBody - (hSlide * newZoom)) / 2;
-  var wPos = (wBody - (wSlide * newZoom)) / 2;
-
   preso.css("zoom", newZoom);
   preso.css("-ms-zoom", newZoom);
   preso.css("-webkit-zoom", newZoom);
-  // Firefox doesn't support zoom
-  // Don't use standard transform to avoid modifying Chrome
-  preso.css("-moz-transform", "scale(" + newZoom + ") translateX(" + wPos + "px) translateY(" + hPos + "px)");
-  preso.css("-moz-transform-origin", "0 0");
+
+  // // Firefox doesn't support zoom.
+  if($("body").hasClass("no-zoom")) {
+    var hPos = 0;
+    var wPos = 0;
+
+    // why so terrible?
+    if($("#preview").hasClass("beside")) {
+      // match the 65/35 split in the stylesheet
+      wBody  *= 0.64;
+      newZoom = Math.min(hBody/hSlide, wBody/wSlide);
+    } else {
+       // Because Firefox's transform doesn't scale up very well
+      newZoom = newZoom > 1 ? 1 : newZoom - .04;
+
+      // Calculate the new offsets to roughly center the preview again
+      var hPos = (hBody - (hSlide * newZoom)) / 2;
+      var wPos = (wBody - (wSlide * newZoom)) / 2;
+    }
+
+    // Don't use standard transform to avoid modifying Chrome
+    preso.css("-moz-transform", "scale(" + newZoom + ") translateX(" + wPos + "px) translateY(" + hPos + "px)");
+    preso.css("-moz-transform-origin", "0 0");
+  }
 
   // correct the zoom factor for the presenter
   if (presenter) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -200,7 +200,6 @@ function zoom(presenter) {
   // Firefox doesn't support zoom
   // Don't use standard transform to avoid modifying Chrome
   preso.css("-moz-transform", "scale(" + newZoom + ") translateX(" + wPos + "px) translateY(" + hPos + "px)");
-  preso.css("-moz-transform-origin", "0 0");
 
   // correct the zoom factor for the presenter
   if (presenter) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -196,8 +196,8 @@ function zoom(presenter) {
       // match the 65/35 split in the stylesheet
       wBody  *= 0.64;
       newZoom = Math.min(hBody/hSlide, wBody/wSlide);
-    } else {
-       // Because Firefox's transform doesn't scale up very well
+    } else if(presenter) { // We only need to offset from center if we're wrapped in the presenter view.
+      // Because Firefox's transform doesn't scale up very well
       newZoom = newZoom > 1 ? 1 : newZoom - .04;
 
       // Calculate the new offsets to roughly center the preview again

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -68,11 +68,6 @@ function setupPreso(load_slides, prefix) {
   // give us the ability to disable tracking via url parameter
   if(query.track == 'false') mode.track = false;
 
-  // make sure that the next view doesn't bugger things on the first load
-  if(query.next == 'true') {
-    mode.next = true;
-  }
-
   // Make sure the slides always look right.
   // Better would be dynamic calculations, but this is enough for now.
   zoom();
@@ -543,7 +538,7 @@ function showSlide(back_step, updatepv) {
 
 
   // Update presenter view, if we spawned one
-	if (updatepv && 'presenterView' in window && ! mode.next) {
+	if (updatepv && 'presenterView' in window) {
     var pv = window.presenterView;
 		pv.slidenum = slidenum;
     pv.incrCurr = incrCurr

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -116,7 +116,7 @@
           <label for="annotationsToggle">Annotations</label><input type="checkbox" id="annotationsToggle" autocomplete="off" />
         </span>
         <span id="enableThumbs" title="Displays thumbnail previews of the next and previous slides.">
-          <label for="thumbsToggle">Previews</label><input type="checkbox" id="thumbsToggle" />
+          <label for="thumbsToggle">Previews</label><input type="checkbox" id="thumbsToggle" autocomplete="off" />
         </span>
       </div>
     </div>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -47,7 +47,7 @@
           <a id="onePage" href="/" title="Switch to Display Window.">Switch Views <i class="fa fa-exchange fa-rotate-90"></i></a>
         </span>
       </span>
-      <select id="layoutSelector">
+      <select id="layoutSelector" autocomplete="off">
         <option value="default" selected>Default Layout</option>
         <option value="thumbs"   title="Display thumbnail previews of the next and previous slides.">Thumbnails</option>
         <option value="floating" title="Open the next slide as a floating window.">Floating</option>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -40,7 +40,6 @@
         </span>
         <span>
           <a id="slaveWindow" href="javascript:toggleSlave();" title="Enable the display window.">Display Window <i class="fa fa-clone"></i></a>
-          <a id="nextWindow" href="javascript:toggleNext();" title="Enable the next window view.">Next Window <i class="fa fa-clone"></i></a>
           <a id="notesWindow" href="javascript:toggleNotes();" title="Enable the popout notes window.">Notes Window <i class="fa fa-clone"></i></a>
         </span>
         <span>
@@ -48,6 +47,12 @@
           <a id="onePage" href="/" title="Switch to Display Window.">Switch Views <i class="fa fa-exchange fa-rotate-90"></i></a>
         </span>
       </span>
+      <select id="layoutSelector">
+        <option value="default" selected>Default Layout</option>
+        <option value="thumbs"   title="Display thumbnail previews of the next and previous slides.">Thumbnails</option>
+        <option value="floating" title="Open the next slide as a floating window.">Floating</option>
+        <option value="beside"   title="Display the next slide as a large preview in the main presenter view.">Side-by-Side</option>
+      </select>
       <span class="mobile">
         <a id="update" href="">Update</a>
       </span>
@@ -114,9 +119,6 @@
         </span>
         <span id="enableAnnotations" title="Enable the annotation system.">
           <label for="annotationsToggle">Annotations</label><input type="checkbox" id="annotationsToggle" autocomplete="off" />
-        </span>
-        <span id="enableThumbs" title="Displays thumbnail previews of the next and previous slides.">
-          <label for="thumbsToggle">Previews</label><input type="checkbox" id="thumbsToggle" autocomplete="off" />
         </span>
       </div>
     </div>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -58,6 +58,10 @@
       </span>
     </span>
   </div>
+  <div id="nextWindowConfirmation">
+    <p>Browser security requires confirmation before opening a new window.</p>
+    <p><a href="javascript:chooseLayout('default');">cancel</a><input type="button" onClick="javascript:openNext();" value="Open Window" /></p>
+  </div>
 
   <div id="center">
     <div id="sidebar">

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -72,11 +72,14 @@
         <img id="paceMarker" src="<%= @asset_path %>/css/paceMarker.png" />
       </div>
       <div id="navigation" class="submenu"></div>
+      <div id="navigationHover"></div>
     </div>
     <div id="presenter">
       <div id="frame">
         <div id="preview">
           <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
+          <div id="prevSlide" class="thumb"></div>
+          <div id="nextSlide" class="thumb"></div>
           <div id="preso">loading presentation...</div>
         </div>
         <div id="annotationToolbar">
@@ -112,7 +115,9 @@
         <span id="enableAnnotations" title="Enable the annotation system.">
           <label for="annotationsToggle">Annotations</label><input type="checkbox" id="annotationsToggle" autocomplete="off" />
         </span>
-
+        <span id="enableThumbs" title="Displays thumbnail previews of the next and previous slides.">
+          <label for="thumbsToggle">Previews</label><input type="checkbox" id="thumbsToggle" />
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Three new ways to preview slides
1. Hover preview over the nav menu
2. Enable previews and the presenter reorders to include prev/next views
3. The popout Next Window is no longer a full presentation, but just a
   receptacle to write the next slide preview into.

Rough edges:
1. The styling doesn't look wonderful in the previews.
2. For some reason, images don't load in the previews. Except for in Edge, where the images are all that loads.
3. Oh Firefox, you so silly.

It would be swell if @marrero984 would work his magic on the styling, but it's a reasonable iteration. Next step is to design a couple different layouts and figure out where to put a layout selector to replace the toggles.

Don't merge this until we get one more release pushed out.
