### PR TITLE
Add simple CSS property detection

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -925,6 +925,17 @@ form .element {
   .callout.stop:before     { content: "\f05e"; } /* fa-ban */
   .callout.thumbsup:before { content: "\f164"; } /* fa-thumbs-up */
 
+/* callouts used on error pages */
+.error .callout {
+  padding-left: 4em;
+  margin: 1em;
+  background-color: #ffe0e0;
+  padding-bottom: 0;
+}
+  .error .callout p:first-of-type {
+    margin-top: 0;
+  }
+
 /**********************
 ***  end callouts   ***
 **********************/

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -28,24 +28,31 @@ var mode = { track: true, follow: true };
 $(document).on('click', 'code.execute', executeCode);
 
 function setupPreso(load_slides, prefix) {
-	if (preso_started)
-	{
-		alert("already started")
-		return
+	if (preso_started) {
+		alert("already started");
+		return;
 	}
-	preso_started = true
+	preso_started = true;
+
+  if (! cssPropertySupported('flex') ) {
+    window.location = 'unsupported.html';
+  }
+
+  if (! cssPropertySupported('zoom') ) {
+    $('body').addClass('no-zoom');
+  }
 
 	// save our query string as an object for later use
 	query = $.parseQuery();
 
 	// Load slides fetches images
-	loadSlidesBool = load_slides
-	loadSlidesPrefix = prefix || '/'
-	loadSlides(loadSlidesBool, loadSlidesPrefix)
+	loadSlidesBool = load_slides;
+	loadSlidesPrefix = prefix || '/';
+	loadSlides(loadSlidesBool, loadSlidesPrefix);
 
   setupSideMenu();
 
-	doDebugStuff()
+	doDebugStuff();
 
 	// bind event handlers
 	toggleKeybinding('on');
@@ -1536,4 +1543,15 @@ function setupStats()
 /* Is this a mobile device? */
 function mobile() {
   return ( $(window).width() <= 480 )
+}
+
+/* check browser support for one or more css properties */
+function cssPropertySupported(properties) {
+  properties = typeof(properties) == 'string' ? Array(properties) : properties
+
+  var supported = properties.filter(function(property){
+    return property in document.body.style;
+  });
+
+  return properties.length == supported.length;
 }

--- a/public/unsupported.html
+++ b/public/unsupported.html
@@ -1,0 +1,35 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Unsupported Browser</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+
+    <link rel="stylesheet" type="text/css" href="/css/showoff.css">
+    <link rel="stylesheet" type="text/css" href="/css/font-awesome-4.4.0/css/font-awesome.min.css">
+  </head>
+
+  <body class="error">
+    <h1>Unsupported Browser</h1>
+    <h2>We regret to inform you that the browser you are using is not supported.</h2>
+
+    <div class="callout warning">
+      <p>
+        Showoff uses many modern web technologies, such as CSS transforms and the
+        <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes">Flexbox layout mode</a>
+        that's only been in use for about five years or so.
+      </p>
+      <p>
+        While we'd dearly love to support your browser of choice, it's genuinely infeasible
+        to do so. Instead, we suggest that you update to a more recent browser. Any major
+        browser released in the last few years will work. Even Internet Explorer 11 or above
+        will work reasonably well.
+      </p>
+      <p>
+        If you are on a corporate Windows machine with locked down installation privileges,
+        we also suggest trying out <a href="http://portableapps.com/apps/internet/google_chrome_portable">Portable Chrome</a>,
+        which will install into a self-contained bundle into your user profile only.
+      </p>
+    </div>
+
+  </body>
+</html>


### PR DESCRIPTION
This will redirect to an error page on super old browsers and will add a
'no-zoom' class to the body tag on Firefox. At some point, we might
consider Modernizer, but I think that's overkill for what we need right
now.

This will support moderately cleaner layout workarounds for funky
browsers. Such as all of them.
