### PR TITLE
Correct the out-of-control preview size on firefox

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -226,7 +226,6 @@
               flex-flow: row;
       -webkit-flex: 10;
               flex: 10;
-      max-height: 95%;  /* dear Firefox; what's the point of flex-box if we still have to do this crap? */
     }
 
     #preview {
@@ -264,6 +263,9 @@
       -webkit-box-shadow:0 0 25px rgba(0,0,0,0.35);
       -moz-box-shadow:0 0 25px rgba(0,0,0,0.35);
       box-shadow:0 0 25px rgba(0,0,0,0.35);
+    }
+    body.no-zoom #preso {
+      position: absolute;
     }
 
     #statusbar {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -68,6 +68,10 @@ pre code {
     background-position: center;
     background-size: cover;
   }
+  /* When we scale on Firefox, keep it centered */
+  #preso {
+    -moz-transform-origin: 0 0;
+  }
 
   .slide {
     font-size: 1.5em;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -200,7 +200,6 @@ function zoom(presenter) {
   // Firefox doesn't support zoom
   // Don't use standard transform to avoid modifying Chrome
   preso.css("-moz-transform", "scale(" + newZoom + ") translateX(" + wPos + "px) translateY(" + hPos + "px)");
-  preso.css("-moz-transform-origin", "0 0");
 
   // correct the zoom factor for the presenter
   if (presenter) {


### PR DESCRIPTION
With `#preso` positioned normally, it affected the size of its parent.
that meant that the container was pushed to a size to fit around the
slide, then we tried to use that size to scale the slide down to fit.
Since it was in a container sized for it, it already fit. But everything
else was boogered.

Setting the `#preso` element to absolute positioning, this pulled it out
of the normal flow, so it didn't affect the layout size of its parent.
That means that our scaling algorithm now works properly.

What a pain in the ass. I will be happy when we figure out a better way.