### PR TITLE
Make annotations work again on IE.

### DIFF
--- a/public/js/annotations.js
+++ b/public/js/annotations.js
@@ -208,7 +208,7 @@ jQuery.fn.extend({
 
       // let the annotation overlay own mouse events.
       // This means that clicking links or copying text will not work.
-      $(this).css('pointer-events', 'initial');
+      $(this).css('pointer-events', 'auto');
 
       $(this).unbind( "mousedown" );
       $(this).mousedown(function(e){


### PR DESCRIPTION
Setting `pointer-events` to `initial` did not work in IE.

Fixes #583 