### PR TITLE
Display incremental bullets properly for audience view

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1410,6 +1410,7 @@ class ShowOff < Sinatra::Application
               if valid_cookie()
                 name  = control['name']
                 slide = control['slide'].to_i
+                increment = control['increment'].to_i rescue 0
 
                 # check to see if we need to enable a download link
                 if @@downloads.has_key?(slide)
@@ -1419,10 +1420,10 @@ class ShowOff < Sinatra::Application
 
                 # update the current slide pointer
                 @logger.debug "Updated current slide to #{name}"
-                @@current = { :name => name, :number => slide }
+                @@current = { :name => name, :number => slide, :increment => increment }
 
                 # schedule a notification for all clients
-                EM.next_tick { settings.sockets.each{|s| s.send({ 'message' => 'current', 'current' => @@current[:number] }.to_json) } }
+                EM.next_tick { settings.sockets.each{|s| s.send({ 'message' => 'current', 'current' => @@current[:number], 'increment' => @@current[:increment] }.to_json) } }
               end
 
             when 'register'

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -444,7 +444,7 @@ function markCompleted(questionID) {
 function update() {
   if(mode.update) {
     var slideName = $("#slideFile").text();
-    ws.send(JSON.stringify({ message: 'update', slide: slidenum, name: slideName}));
+    ws.send(JSON.stringify({ message: 'update', slide: slidenum, name: slideName, increment: incrCurr}));
   }
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -461,8 +461,9 @@ function setupSlideParamsCheck() {
 function gotoSlide(slideNum, updatepv) {
   var newslide = parseInt(slideNum);
   if (slidenum != newslide && !isNaN(newslide)) {
+    var back = (newslide == (slidenum - 1))
     slidenum = newslide;
-    showSlide(false, updatepv);
+    showSlide(back, updatepv);
   }
 }
 
@@ -902,7 +903,7 @@ function parseMessage(data) {
   try {
     switch (command['message']) {
       case 'current':
-        follow(command["current"]);
+        follow(command["current"], command["increment"]);
         break;
 
       case 'complete':
@@ -1032,10 +1033,29 @@ function editSlide() {
   window.open(link);
 }
 
-function follow(slide) {
+function follow(slide, newIncrement) {
   if (mode.follow) {
+    var lastSlide = slidenum;
     console.log("New slide: " + slide);
     gotoSlide(slide);
+
+    if( ! $("body").hasClass("presenter") ) {
+      switch (slidenum - lastSlide) {
+        case -1:
+          fireEvent("showoff:prev");
+          break;
+
+        case 1:
+          fireEvent("showoff:next");
+          break;
+      }
+
+      // if the master says we're incrementing. Use a loop in case the viewer is out of sync
+      while(newIncrement > incrCurr) {
+        increment();
+      }
+
+    }
   }
 }
 
@@ -1044,41 +1064,44 @@ function getPosition() {
   ws.send(JSON.stringify({ message: 'position' }));
 }
 
+function fireEvent(ev) {
+  var event = jQuery.Event(ev);
+  $(currentSlide).find(".content").trigger(event);
+  if (event.isDefaultPrevented()) {
+    return;
+  }
+}
+
+function increment() {
+  showIncremental(incrCurr);
+
+  var incrEvent = jQuery.Event("showoff:incr");
+  incrEvent.slidenum = slidenum;
+  incrEvent.incr = incrCurr;
+  $(currentSlide).find(".content").trigger(incrEvent);
+
+  incrCurr++;
+}
+
 function prevStep(updatepv)
 {
-	var event = jQuery.Event("showoff:prev");
-	$(currentSlide).find(".content").trigger(event);
-	if (event.isDefaultPrevented()) {
-			return;
-	}
-
+  fireEvent("showoff:prev");
   track();
-
-	slidenum--
-	return showSlide(true, updatepv) // We show the slide fully loaded
+  slidenum--;
+  return showSlide(true, updatepv); // We show the slide fully loaded
 }
 
 function nextStep(updatepv)
 {
-	var event = jQuery.Event("showoff:next");
-	$(currentSlide).find(".content").trigger(event);
-	if (event.isDefaultPrevented()) {
-			return;
-	}
+  fireEvent("showoff:next");
+  track();
 
-	track();
-
-	if (incrCurr >= incrSteps) {
-		slidenum++
-		return showSlide(false, updatepv)
-	} else {
-		showIncremental(incrCurr);
-		var incrEvent = jQuery.Event("showoff:incr");
-		incrEvent.slidenum = slidenum;
-		incrEvent.incr = incrCurr;
-		$(currentSlide).find(".content").trigger(incrEvent);
-		incrCurr++;
-	}
+  if (incrCurr >= incrSteps) {
+    slidenum++;
+    return showSlide(false, updatepv);
+  } else {
+    increment();
+  }
 }
 
 // carrying on our grand tradition of overwriting functions of the same name with presenter.js

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -13,7 +13,7 @@
   </script>
 </head>
 
-<body>
+<body class="presenter">
 <%= erb :help %>
 
 <div id="main">


### PR DESCRIPTION
Now when audience members load the presentation on their browser,
they'll enjoy the same incremental bullet effects that the display view
up on the projector currently does.

Fixes #564