### PR TITLE
Pins the hamburger to the upper left, as it should

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -44,9 +44,6 @@ pre code {
   /* explicitly size parent elements so the screen blanker works */
   html, body{
     height:100%;
-  }
-
-  body {
     margin:0;
     padding:0;
     overflow: hidden;


### PR DESCRIPTION
The `body` element was not rendered until it had visible children
elements. Because the visible child (`#preso`) had a `margin-top`, this
means that the `body` was also rendered beginning that far away from the
top.

http://craphound.com/images/css_is_awesome.jpg