### PR TITLE
Adds the ability to reference sections from other files

### DIFF
--- a/documentation/PRESENTATION.rdoc
+++ b/documentation/PRESENTATION.rdoc
@@ -156,13 +156,50 @@ Array configuration listing each Markdown file:
       "Conclusion/overview.md",
     ]
 
-Hash configuration listing each directory of Markdown files:
+Hash configuration listing each section as a directory of Markdown files:
 
     "sections": [
       {"section":"one"},
       {"section":"two"},
       {"section":"three"},
       {"section":"four"}
+    ]
+
+Hash configuration listing sections as arrays of Markdown files:
+
+    "sections": [
+      {
+        "section":[
+          "Intro/intro.md",
+          "Intro/summary.md"
+        ]
+      },
+      {
+        "section":[
+          "Content/first.md",
+          "Content/second.md"
+        ]
+      },
+      {
+        "section":[
+          "Conclusion/overview.md"
+        ]
+      }
+    ]
+
+Hash configuration including sections from other <tt>JSON</tt> files:
+
+    "sections": [
+      {"include":"Intro/section.json"},
+      {"include":"Content/section.json"},
+      {"include":"Conclusion/section.json"}
+    ]
+
+Each of the referenced <tt>JSON</tt> files should list Markdown files in an array:
+
+    [
+      "intro.md",
+      "summary.md"
     ]
 
 == Running without a <tt>showoff.json</tt>

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -226,7 +226,7 @@ class ShowOff < Sinatra::Application
       files = if File.directory? section
         Dir.glob("#{section}/**/*").sort
       else
-        [section]
+        Array(section)
       end
       @logger.debug files
       files


### PR DESCRIPTION
Instead of listing all the `.md` files in one monolithic `showoff.json`,
you can reference smaller section files, like such:

``` json
"sections": [
  {"include":"Intro/section.json"},
  {"include":"Content/section.json"},
  {"include":"Conclusion/section.json"}
]
```

Each one of those would be just a list of slides as a JSON encoded
array, which is easier to make into a composable set of units.