### PR TITLE
Don't display notes when bigtext enabled

### DIFF
--- a/example/bigtext/slides.md
+++ b/example/bigtext/slides.md
@@ -1,0 +1,34 @@
+<!SLIDE>
+
+# Regular text
+
+~~~SECTION:notes~~~
+
+One line of notes
+Two lines of notes
+
+~~~ENDSECTION~~~
+
+<!SLIDE bigtext>
+
+# BIGTEXT
+
+~~~SECTION:notes~~~
+
+These are the notes
+
+~~~ENDSECTION~~~
+
+<!SLIDE bigtext>
+
+## Big Text
+
+~~~SECTION:notes~~~
+
+One line of notes
+Two lines of notes
+
+~~~ENDSECTION~~~
+
+
+


### PR DESCRIPTION
The bigtext styling overrides the `display:none` on the notes div. This
moves notes *outside* of the content div (where it should be anyway) and
removes the `bigtext` class from the slide so that other elements (like
annotations, etc) aren't also caught by this.

Fixes #614