### PR TITLE
Render diagrams when slides are shown

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -187,8 +187,8 @@ function initializePresentation(prefix) {
     }
   });
 
-  // render diagrams
-  mermaid.init(undefined, $(".language-render-diagram"));
+  // initialize mermaid, but don't render yet since the slide sizes are indeterminate
+  mermaid.initialize({startOnLoad:false});
 
   $("#preso").trigger("showoff:loaded");
 }
@@ -584,6 +584,9 @@ function showSlide(back_step, updatepv) {
 
   // make all bigly text tremendous
   currentSlide.children('.content.bigtext').bigtext();
+
+  // render any diagrams on the slide
+  mermaid.init(undefined, currentSlide.find('code.language-render-diagram'));
 
   return ret;
 }


### PR DESCRIPTION
When the slideshow is started, the slide size is indeterminate. This
causes Mermaid to not know the correct SVG size, so it renders them
virtually invisible.

Doing it as the slide is shown means that the size is known.