### PR TITLE
Allows `showoff static` to use alternate json files

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -286,8 +286,12 @@ desc 'Generate static version of presentation'
 arg_name 'name'
 long_desc 'Creates a static, one page version of the presentation as {name}.html'
 command [:static] do |c|
+  c.desc 'JSON file used to describe presentation'
+  c.default_value "showoff.json"
+  c.flag [:f, :file, :pres_file]
+
   c.action do |global_options,options,args|
-    ShowOff.do_static(args)
+    ShowOff.do_static(args, options)
   end
 end
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -77,7 +77,7 @@ class ShowOff < Sinatra::Application
     @keycode_shifted_keys = Keymap.shiftedKeyDictionary
 
     settings.pres_dir = File.expand_path(settings.pres_dir)
-    if (settings.pres_file)
+    if (settings.pres_file and settings.pres_file != 'showoff.json')
       ShowOffUtils.presentation_config_file = settings.pres_file
     end
 
@@ -1122,10 +1122,12 @@ class ShowOff < Sinatra::Application
   end
 
 
-   def self.do_static(args)
+   def self.do_static(args, opts = {})
       args ||= [] # handle nil arguments
       what   = args[0] || "index"
       opt    = args[1]
+
+      ShowOffUtils.presentation_config_file = opts[:f]
 
       # Sinatra now aliases new to new!
       # https://github.com/sinatra/sinatra/blob/v1.3.3/lib/sinatra/base.rb#L1369


### PR DESCRIPTION
Fixes #621