### PR TITLE
Fixed Heroku presentations

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -98,7 +98,7 @@ end
 desc 'Serves the showoff presentation in the current directory'
 desc 'Setup your presentation to serve on Heroku'
 arg_name 'heroku_name'
-long_desc 'Creates the Gemfile and config.ru file needed to push a showoff pres to heroku.  It will then run ''heroku create'' for you to register the new project on heroku and add the remote for you.  Then all you need to do is commit the new created files and run ''git push heroku'' to deploy.'
+long_desc 'Creates the configuration files needed to Herokuize a Showoff presentation and then deploys it for you.'
 command :heroku do |c|
 
   c.desc 'add password protection to your heroku site'
@@ -107,29 +107,36 @@ command :heroku do |c|
   c.desc 'force overwrite of existing Gemfile/.gems and config.ru files if they exist'
   c.switch [:f,:force]
 
-  c.desc 'Use older-style .gems file instead of bundler-style Gemfile'
-  c.switch [:g,:dotgems]
-
   c.action do |global_options,options,args|
     raise "heroku_name is required" if args.empty?
-    if ShowOffUtils.heroku(args[0],options[:f],options[:p],options[:g])
-      puts "herokuized. run something like this to launch your heroku presentation:
+    raise "Name must start with a letter and can only contain lowercase letters, numbers, and dashes." unless args.first =~ /^[a-z][a-z1-9-]*$/
 
-      heroku create #{args[0]}"
+    unless system('git remote get-url heroku')
+      ShowOffUtils.command("heroku create #{args[0]}", "Please ensure that the heroku gem is installed and you're logged in.")
+    end
 
-      if options[:g]
-      puts "        git add .gems config.ru"
-      else
-      puts "      bundle install"
-      puts "      git add Gemfile Gemfile.lock config.ru"
+    if ShowOffUtils.heroku(args[0],options[:f],options[:p])
+      ShowOffUtils.command('bundle install', 'Please ensure that the bundler gem is installed.')
+
+      begin
+        ShowOffUtils.command('git add Procfile Gemfile Gemfile.lock config.ru')
+        ShowOffUtils.command('git commit -m "Herokuized by Showoff"')
+        ShowOffUtils.command('git push heroku master')
+      rescue => e
+        puts 'Git operations failed. Please correct issues, then manually commit the following files:'
+        puts ' * Procfile'
+        puts ' * Gemfile'
+        puts ' * Gemfile.lock'
+        puts ' * config.ru'
+        puts
+        puts 'When done, please run "git push heroku master"'
       end
-      puts "      git commit -m 'herokuized'
-      git push heroku master
-      "
 
       if options[:p]
         puts "CAREFUL: you are commiting your access password - anyone with read access to the repo can access the preso\n\n"
       end
+
+      puts 'Your presentation has been Herokuized. Run `heroku open` to see it.'
     end
   end
 end

--- a/documentation/COMMANDLINE.rdoc
+++ b/documentation/COMMANDLINE.rdoc
@@ -66,7 +66,12 @@ Options are specified *after* the command.
 
 Setup your presentation to serve on Heroku
 
-Creates the Gemfile and config.ru file needed to push a showoff pres to heroku.  It will then run heroku create for you to register the new project on heroku and add the git remote for you.  Then all you need to do is commit the new created files and run <tt>git push heroku</tt> to deploy.
+Creates the configuration files needed to Herokuize a Showoff presentation and then deploy it for you.
+This will register the new project on Heroku if needed and create the git remote for you.
+
+Open your new presentation by running <tt>heroku open</tt>.
+
+Requires the <tt>heroku</tt> and <tt>bundler</tt> gems to be installed properly.
 
 
 == <tt>showoff github</tt>

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -43,6 +43,7 @@ class ShowOff < Sinatra::Application
   set :verbose, false
   set :review,  false
   set :execute, false
+  set :nocache, false
 
   set :pres_dir, '.'
   set :pres_file, 'showoff.json'
@@ -50,6 +51,7 @@ class ShowOff < Sinatra::Application
   set :pres_template, nil
   set :showoff_config, {}
   set :encoding, nil
+  set :url, nil
 
   def initialize(app=nil)
     super(app)


### PR DESCRIPTION
* Corrected the `config.ru` to properly launch a presentation.
* Corrected uninitialized variables when launching via `config.ru`.
* Removed way-way-way-way deprecated `.gems` support.
* Made the behaviour of the command match the docs.
* Cleaned up output a bit.

Fixes #632