### PR TITLE
This saves the state of the UI in cookies.

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -64,6 +64,17 @@ $(document).ready(function(){
     minHeight: 0,
     handles: {"n": $(".notes-grippy")}
   });
+  $("#notes").resize(function(){
+    document.cookie = "notes="+$('#notes').height();
+  });
+
+
+  // restore the UI settings
+  var ui = document.cookieHash['ui'];
+  $('#notes').height(document.cookieHash['notes']);
+  if(! document.cookieHash['sidebar']) {
+    toggleSidebar();
+  }
 
   // Hide with js so jquery knows what display property to assign when showing
   toggleAnnotations();
@@ -282,6 +293,8 @@ function toggleSidebar() {
     $('#topbar #close-sidebar').toggleClass('fa-rotate-90');
     $('#sidebar').toggle();
     zoom(true);
+
+    document.cookie = "sidebar="+$('#sidebar').is(':visible');
   }
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -32,6 +32,10 @@ document.cookie.split(';').forEach( function(item) {
   var pos = item.indexOf('=');
   var key = item.slice(0,pos).trim();
   var val = item.slice(pos+1).trim();
+  try {
+    val = JSON.parse(val);
+  }
+  catch(e) { }
 
   document.cookieHash[key] = val;
 });


### PR DESCRIPTION
The sidebar and the size of the notes panel will be restored on the next
load. This will not pop the notes panel out again (floating window) if
you had it popped out already. I'm not convinced that's good UI.

TODO:
 * The layout cookies should probably be a single cookie.
 * There should be a way to reset the UI to default.

Fixes #622