### PR TITLE
Default to sidebar open

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -72,7 +72,7 @@ $(document).ready(function(){
   // restore the UI settings
   var ui = document.cookieHash['ui'];
   $('#notes').height(document.cookieHash['notes']);
-  if(! document.cookieHash['sidebar']) {
+  if(document.cookieHash['sidebar'] == false) {
     toggleSidebar();
   }
 


### PR DESCRIPTION
Explicitly check for `false`, rather than the absence of `true`.