### PR TITLE
Always highlight pre code

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -470,7 +470,7 @@ class ShowOff < Sinatra::Application
         file = "Empty file: #{name}" if file.empty?
         file = HTMLEntities.new.encode(file) rescue "HTML parsing of #{name} failed"
 
-        result.gsub!(match[0], "<pre class=\"highlight\"><code class=\"#{css}\">#{file}</code></pre>")
+        result.gsub!(match[0], "<pre><code class=\"#{css}\">#{file}</code></pre>")
       end
 
       result
@@ -858,7 +858,6 @@ class ShowOff < Sinatra::Application
           lines = out.split("\n")
           if lines.first.strip[0, 3] == '@@@'
             lang = lines.shift.gsub('@@@', '').strip
-            pre.set_attribute('class', 'highlight')
             code.set_attribute('class', 'language-' + lang.downcase) if !lang.empty?
             code.content = lines.join("\n")
           end

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -595,8 +595,8 @@ img#disconnected {
 }
 
 /* Add Console "code highlighting" styles to resemble the look of a terminal window. */
-pre.highlight code.language-console,
-pre.highlight code.console {
+pre code.language-console,
+pre code.console {
   background: #222;
   background: url(titlebar/left.png) left top no-repeat, url(titlebar/right.png) right top no-repeat, url(titlebar/center.png) center top repeat-x #222;
   color: #63de00;
@@ -609,8 +609,8 @@ pre.highlight code.console {
   overflow: hidden;
 }
 
-pre.highlight code.language-powershellconsole,
-pre.highlight code.powershellconsole {
+pre code.language-powershellconsole,
+pre code.powershellconsole {
   background: rgb(1, 36, 86);
   background: url(titlebar/powershell-controls.png) right top no-repeat, url(titlebar/powershell.png) left top repeat-x rgb(1, 36, 86);
   color: rgb(238, 237, 240);
@@ -621,8 +621,8 @@ pre.highlight code.powershellconsole {
   overflow: hidden;
 }
 
-pre.highlight code.language-console.nochrome,
-pre.highlight code.language-powershellconsole.nochrome {
+pre code.language-console.nochrome,
+pre code.language-powershellconsole.nochrome {
   background-image: none;
   border-width: 1px;
   padding: 0.5em;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -165,7 +165,7 @@ function initializePresentation(prefix) {
   // Remove spinner in case we're reloading
   $('body').removeClass('busy');
 
-  $('pre.highlight code').each(function(i, block) {
+  $('pre code').each(function(i, block) {
     try {
       hljs.highlightBlock(block);
     } catch(e) {

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -43,7 +43,7 @@
 
   <script type="text/javascript">
     $(document).ready(function() {
-      $('pre.highlight code').each(function(i, block) {
+      $('pre code').each(function(i, block) {
         try {
           hljs.highlightBlock(block);
         } catch(e) {


### PR DESCRIPTION
CommonMarker doesn't place the "highlight" class on `<pre>` tags,
which fails to highlight them.

I can't think of a case where `<pre><code></code></pre>` shouldn't be
highlighted, and in such cases, you could always manually add the
`nohighlight` class, which is honored by highlightjs.