### PR TITLE
Convert progress text to a graphical progressbar

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -449,9 +449,21 @@
       background: #fff;
     }
       #progress {
-        margin-left: 1em;
-        position: relative;
+        float: left;
+        width: 25%;
+        height: 20px;
+        background: #ffb105;
       }
+        #progress .label {
+          position: absolute;
+          padding: 0 0.25em;
+          font-size: 10px;
+          color: #fff;
+        }
+        #progress .ui-progressbar-value {
+          border: 1px solid #003eff;
+          background: #007fff;
+        }
       #debugInfo {
         display: inline;
       }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -68,6 +68,8 @@ $(document).ready(function(){
     document.cookie = "notes="+$('#notes').height();
   });
 
+  // Turn the progress display into an actual progressbar
+  $('#progress').progressbar({max:100})
 
   // restore the UI settings
   var ui = document.cookieHash['ui'];
@@ -592,6 +594,7 @@ function postSlide() {
 
 		var fileName = currentSlide.children('div').first().attr('ref');
 		$('#slideFile').text(fileName);
+    $('#progress').progressbar('value', getSlidePercent());
 
     $("#notes div.form.wrapper").each(function(e) {
       renderFormInterval = renderFormWatcher($(this));

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -122,9 +122,7 @@
     </div>
 
     <div id="statusbar">
-      <span id="progress" class="no-mobile">
-        Slide: <span id="slideInfo"></span>
-      </span>
+      <div id="progress" class="no-mobile"><span class="label">Slide: <span id="slideInfo"></span></span></div>
       <div id="debugInfo"></div>
 
       <div class="controls">


### PR DESCRIPTION
Three style options, not sure I'm totally happy with any of them, but weigh in.

<img width="823" alt="screen shot 2017-01-13 at 1 45 08 pm" src="https://cloud.githubusercontent.com/assets/1392917/21946773/cbbab962-d996-11e6-919d-74d6dfb9bd6e.png">
<img width="818" alt="screen shot 2017-01-13 at 1 44 40 pm" src="https://cloud.githubusercontent.com/assets/1392917/21946774/cbbb3626-d996-11e6-8372-b6942c657a4a.png">
<img width="814" alt="screen shot 2017-01-13 at 1 44 01 pm" src="https://cloud.githubusercontent.com/assets/1392917/21946775/cbbb8522-d996-11e6-8ec8-cd03ebd4801d.png">

It feels a little busy down there now. Especially if you have a slide with multiple notes sections.

<img width="825" alt="screen shot 2017-01-13 at 1 49 08 pm" src="https://cloud.githubusercontent.com/assets/1392917/21946872/24bd36c0-d997-11e6-9252-e8156bb400e4.png">
