### PR TITLE
Add glossary/endnote functionality

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -567,7 +567,7 @@ class ShowOff < Sinatra::Application
           definition.children.before(label)
 
           [doc.css('div.notes-section.notes'), doc.css('div.notes-section.handouts')].each do |section|
-            section.children.after(definition.clone)
+            section.first.add_child(definition.clone)
           end
 
         else

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -528,7 +528,7 @@ class ShowOff < Sinatra::Application
 
         glossary = (item.attr('class').split - ['callout', 'glossary']).first
         address  = glossary ? "#{glossary}/#{$2}" : $2
-        frag     = "<a class=\"processed\" href=\"glossary://#{address}\">#{$1}</a>"
+        frag     = "<a class=\"processed label\" href=\"glossary://#{address}\">#{$1}</a>"
 
         item.children.before(Nokogiri::HTML::DocumentFragment.parse(frag))
       end
@@ -536,7 +536,7 @@ class ShowOff < Sinatra::Application
       # Process links
       doc.css('a').each do |link|
         next if link['href'].start_with? '#'
-        next if link['class'] == 'processed'
+        next if link['class'].split.include? 'processed' rescue nil
 
         # If these are glossary links, populate the notes/handouts sections
         if link['href'].start_with? 'glossary://'
@@ -552,6 +552,11 @@ class ShowOff < Sinatra::Application
           target = parts.pop
           name   = parts.pop # either the glossary name or nil
 
+          link['class']  = 'term'
+
+          label = link.clone
+          label['class'] = 'label processed'
+
           frag = Nokogiri::HTML::DocumentFragment.parse('<p></p>')
           definition = frag.children.first
           definition['class'] = "callout glossary #{name}"
@@ -559,7 +564,7 @@ class ShowOff < Sinatra::Application
           definition['data-target'] = target
           definition['data-text']   = text
           definition.content = text
-          definition.children.before(link.clone)
+          definition.children.before(label)
 
           [doc.css('div.notes-section.notes'), doc.css('div.notes-section.handouts')].each do |section|
             section.children.after(definition.clone)
@@ -652,7 +657,7 @@ class ShowOff < Sinatra::Application
           anchor = "#{page}+#{link}"
           next if href.nil? or text.nil? or link.nil?
 
-          frag = "<li><a id=\"#{anchor}\">#{term}</a>#{text}<a href=\"##{href}\">↩</a></li>"
+          frag = "<li><a id=\"#{anchor}\" class=\"label\">#{term}</a>#{text}<a href=\"##{href}\" class=\"return\">↩</a></li>"
           item = Nokogiri::HTML::DocumentFragment.parse(frag)
 
           list.children.first.add_child(item)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -492,12 +492,6 @@ class ShowOff < Sinatra::Application
       # Turn this into a document for munging
       doc = Nokogiri::HTML::DocumentFragment.parse(result)
 
-      if opts[:section]
-        doc.css('div.notes-section').each do |section|
-          section.remove unless section.attr('class').split.include? opts[:section]
-        end
-      end
-
       filename = File.join(settings.pres_dir, '_notes', "#{name}.md")
       @logger.debug "personal notes filename: #{filename}"
       if [nil, 'notes'].include? opts[:section] and File.file? filename
@@ -573,6 +567,13 @@ class ShowOff < Sinatra::Application
         else
           # Add a target so we open all external links from notes in a new window
           link.set_attribute('target', '_blank')
+        end
+      end
+
+      # finally, remove any sections we don't want to print
+      if opts[:section]
+        doc.css('div.notes-section').each do |section|
+          section.remove unless section.attr('class').split.include? opts[:section]
         end
       end
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -521,7 +521,10 @@ class ShowOff < Sinatra::Application
 
       # Now add a target so we open all external links from notes in a new window
       doc.css('a').each do |link|
-        link.set_attribute('target', '_blank') unless link['href'].start_with? '#'
+        next if link['href'].start_with? '#'
+        next if link['href'].start_with? 'glossary://'
+
+        link.set_attribute('target', '_blank')
       end
 
       doc.to_html

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -972,6 +972,32 @@ form .element {
 /**********************
 ***  end callouts   ***
 **********************/
+.callout.glossary a.label,
+ul.glossary.terms a.label {
+  display: block;
+  font-weight: 600;
+  text-decoration: none;
+}
+ul.glossary.terms a.return {
+  text-decoration: none;
+  padding-right: 3em;
+}
+a.term {
+  text-decoration: none;
+}
+a.term:after {
+  font-family: FontAwesome;
+  font-size: 0.8em;
+  vertical-align: super;
+  content: "\f27b";
+  text-decoration: none;/* fa-commenting-o */
+}
+
+
+/**********************
+***  glossary       ***
+**********************/
+
 
 /* Render hidden headlines so that when we print with wkhtmltopdf, we can use section
    titles for page headers.  it would make sense to put this in the print section, but

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -944,7 +944,8 @@ form .element {
   .callout.exercise,
   .callout.stop,
   .callout.thumbsup,
-  .callout.conversation {
+  .callout.conversation,
+  .callout.glossary {
     padding-left: 3em;
   }
 
@@ -955,6 +956,7 @@ form .element {
   .callout.stop:before         { content: "\f05e"; } /* fa-ban */
   .callout.thumbsup:before     { content: "\f164"; } /* fa-thumbs-up */
   .callout.conversation:before { content: "\f0e5"; } /* fa-comment */
+  .callout.glossary:before     { content: "\f02d"; } /* fa-book */
 
 /* callouts used on error pages */
 .error .callout {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -460,12 +460,13 @@ function currentSlideFromName(name) {
 
 function currentSlideFromParams() {
 	var result;
-	if (result = window.location.hash.match(/#([0-9]+)/)) {
-		return result[result.length - 1] - 1;
+	// Match numeric slide hashes: #241
+	if (result = window.location.hash.match(/^#([0-9]+)$/)) {
+		return result[1] - 1;
 	}
-	else {
-	  var hash = window.location.hash
-	  return currentSlideFromName(hash.substr(1, hash.length))
+	// Match slide, with optional internal mark: #slideName(+internal)
+	else if (result = window.location.hash.match(/^#([^+]+)\+?(.*)?$/)) {
+	  return currentSlideFromName(result[1]);
   }
 }
 


### PR DESCRIPTION
This will allow the user to add glossary terms, either inline or in `.callout` notes. This is intentionally undocumented for now, as it's not considered to be production ready yet.

On a slide, use something like the following to add both an entry in the notes/handouts and to a page tagged with `glossary`.

    [a phrase](glossary://term-with-no-spaces "The definition of the term.")

You can also add a term to the notes/handouts, in which case it will be listed on the glossary page, but not shown on slide:

    .callout.glossary By hand, yo!|by-hand: I made this one by hand.

You can also add a term to a *named* glossary inline:

    [a phrase](glossary://name/term-with-no-spaces "The definition of the term.")

Or as a note:

    .callout.glossary.name By hand, yo!|by-hand: I made this one by hand.

-----

The glossary page is simply tagged with `glossary` and an optional name.

    <!SLIDE glossary>
    # General Glossary

    You can add any markdown you want up here. A list of glossary items will be added to the end.

A named glossary

    <!SLIDE glossary name>
    # This is a named glossary

    You can add any markdown you want up here. A list of glossary items will be added to the end.


Fixes #227 