### PR TITLE
Makes the viewing stats more useful

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -78,6 +78,9 @@
   #links a.enabled {
     background-color: #003d96;
   }
+  #links a.warning {
+    background-color: #8e030a;
+  }
 
   #links .mobile {
     display: none;
@@ -107,6 +110,10 @@
   #presenterPopup a,
   #nextWindowConfirmation a {
     color: #ffffff;
+  }
+
+  #presenterPopup #stats .zoomline {
+    color: #000;
   }
 
 #nextWindowConfirmation {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -843,6 +843,7 @@ form .element {
   -webkit-border-radius: 5px;
   -khtml-border-radius: 5px;
   border-radius: 5px;
+  cursor: default;
 }
 /* and to the bar inside the row */
 #stats div.bar {
@@ -862,6 +863,54 @@ form .element {
   position: absolute;
   top: 0.15em;
   right: 0.25em;
+}
+
+/* Add the disclosure triangles */
+#stats div.row:before {
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 1.25em;
+  text-decoration: inherit;
+}
+  #stats div.row.top:hover:before {
+    position: absolute;
+    content: "\f0da"; /* fa-caret-right */
+    margin-left: -0.5em;
+  }
+  #stats div.row.top.active:before {
+    position: absolute;
+    content: "\f0d7"; /* fa-caret-down */
+    margin-left: -0.75em;
+  }
+
+#stats h2 {
+  border-bottom: 1px solid #eee;
+}
+#stats #viewers,
+#stats #elapsed {
+  text-align: center;
+  min-height: 2em;
+}
+#stats #viewers.zoomline,
+#stats #elapsed.zoomline {
+  text-align: left;
+}
+#stats .zoomline .col.current .inner {
+  background-color: #edd46f;
+  min-width: 5px;
+}
+#stats .zoomline .col.current .inner:hover {
+  background-color: #f3708d;
+}
+
+#stats #stray {
+  display: none;
+  width: 75%;
+  margin: 1em auto;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  background-color: #8e030a;
 }
 
 /* style all three boxes */

--- a/public/css/zoomline-0.0.1.css
+++ b/public/css/zoomline-0.0.1.css
@@ -1,0 +1,66 @@
+.zoomline {
+  width: 85%;
+  background-color: #efefec;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin: 12px auto;
+  padding-top: 1em;
+  clear: both;
+  position: relative;
+}
+
+  .zoomline .chart {
+    width: 95%;
+    height: 64px;
+    cursor: pointer;
+    font-size: 0;
+    overflow: hidden;
+    vertical-align: bottom;
+    padding-top: 3px;
+    margin: 3px auto;
+  }
+    .zoomline .chart .col {
+      position: relative;
+      display: inline-block;
+      vertical-align: bottom;
+      width: 2px;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      font-size: 10px;
+      transition: width 200ms;
+    }
+      .zoomline .chart .col:hover {
+        min-width: 10px;
+        background: #ffe0e7;
+        background: linear-gradient(#efefec, #ffe0e7);
+      }
+
+      .zoomline .chart .col .inner {
+        position: absolute;
+        bottom: 0;
+        display: inline-block;
+        width: 100%;
+        min-height: 4px;
+        margin: 0;
+        padding: 0;
+        background-color: #bbbbbb;
+      }
+      .zoomline .chart .col:hover .inner {
+        background-color: #f3708d;
+        border-top: 3px solid #f3708d;
+        border-radius: 3px 3px 0 0;
+      }
+
+  .zoomline .label {
+    min-height: 1em;
+    padding: 0 4px;
+    position: absolute;
+    top: 0;
+  }
+    .zoomline .label.left {
+      left: 0;
+    }
+    .zoomline .label.right {
+      right: 0;
+    }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -126,6 +126,28 @@ $(document).ready(function(){
 
   setInterval(function() { updatePace() }, 1000);
 
+  setInterval(function() {
+    $.getJSON("/stats_data", function( json ) {
+      if (json['stray_p']) {
+        var percent = json['stray_p'];
+        if(percent > 25) {
+          $('#topbar #statslink').addClass('warning');
+          $('#topbar #statslink').attr('title', percent + "% of your audience is not viewing the same slide you are.");
+        }
+        else {
+          $('#topbar #statslink').removeClass('warning');
+          $('#topbar #statslink').attr('title', "");
+        }
+      }
+
+      if( $('#presenterPopup #stats').is(':visible') ) {
+        setupStats(json);
+      }
+    });
+
+  }, 30000);
+
+
   // Tell the showoff server that we're a presenter
   register();
 
@@ -171,8 +193,6 @@ function presenterPopupToggle(page, event) {
       /* use .siblings() because of how jquery formats $(data) */
       content.append($(data).siblings('#wrapper').html());
       popup.append(content);
-
-      setupStats(); // this function is in showoff.js because /stats does not load presenter.js
 
       $('body').append(popup);
       popup.slideDown(200); // #presenterPopup is display: none by default

--- a/public/js/zoomline-0.0.1.js
+++ b/public/js/zoomline-0.0.1.js
@@ -1,0 +1,108 @@
+/* Example usage:
+    var shortdata = [
+      [  63, "About_Puppet/About_Puppet",         "00:01:03" ],
+      [  81, "About_Puppet/Current_State",        "00:01:21" ],
+      [ 282, "About_Puppet/How_Puppet_Works",     "00:04:42" ],
+      [ 347, "About_Puppet/Introducing_PE",       "00:05:47", "current" ],
+      [  33, "About_Puppet/Objectives",           "00:00:33" ],
+      [  67, "About_Puppet/Puppet_Works_Define3", "00:01:07" ]
+    ];
+
+    var numbers = [
+      23,
+      64,
+      22,
+      91,
+      38,
+      12,
+      87,
+      [76, null, null, "current" ],
+      54,
+      43,
+      32,
+      21,
+      19
+    ];
+
+  $(document).ready(function(){
+
+    $(".shortline").zoomline({
+      max: 360
+      data: shortdata,
+      callback: function(element) { alert("The time is: " + element.attr("data-right")); }
+    });
+
+    $(".numbers").zoomline({
+      data: numbers
+    });
+  });
+
+*/
+
+(function ( $ ) {
+    $.fn.zoomline = function(options) {
+      var settings = $.extend({
+         data: [],
+          max: 100,
+        click: function(element) {
+          alert( element.attr("data-left") || element.attr("data-right") || element.attr("data-size") );
+        }
+      }, options );
+
+      return this.each(function() {
+        var zoomline = $(this);
+        var chart    = $("<div>", { "class": "chart" });
+
+        zoomline.empty();
+        zoomline.addClass("zoomline");
+        zoomline.append(chart);
+
+        var width     = chart.width();
+        var barwidth  = width/settings.data.length;
+        // if we have to zoom the focused bar for visibility, make room for it.
+        var widewidth = (barwidth < 10) ? (width + (10 - barwidth)) : width
+
+        settings.data.forEach(function(item) {
+          // coerce into array, so we can accept either numbers or arrays
+          item = (typeof(item) == "number") ? [item] : item
+
+          var height = (item[0]/settings.max * 100) + "%"
+          var column = $("<div>", { "class": "col" });
+          column.attr("data-size",  item[0])
+          if (1 in item) { column.attr("data-left",  item[1]) }
+          if (2 in item) { column.attr("data-right", item[2]) }
+          if (3 in item) { column.addClass(item[3]) }
+
+          column.css("width", barwidth+"px");
+          column.append($("<div>", { "class": "inner", height: height }));
+
+          chart.append(column);
+        });
+
+        var left  = $("<div>", { "class": "label left"  });
+        var right = $("<div>", { "class": "label right" });
+        zoomline.append(left);
+        zoomline.append(right);
+
+        chart.hover(function(e) {
+          $(this).width(widewidth);
+        }, function(e){
+          $(this).width(width);
+          left.text('');
+          right.text('')
+        });
+
+        chart.children(".col").hover(function(e) {
+          left.text( $(this).attr("data-left") );
+          right.text( $(this).attr("data-right") || $(this).attr("data-size") );
+        });
+
+        chart.children(".col").click(function(e) {
+          settings.click( $(this) );
+        });
+
+        return this;
+      });
+    };
+
+}(jQuery));

--- a/views/header.erb
+++ b/views/header.erb
@@ -11,6 +11,7 @@
   <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/mermaid-6.0.0.css" />
   <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/font-awesome-4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
+  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/zoomline-0.0.1.css">
 
   <script type="text/javascript" src="<%= @asset_path %>/js/jquery-2.1.4.min.js"></script>
 
@@ -20,6 +21,7 @@
   <script type="text/javascript" src="<%= @asset_path %>/js/jquery.doubletap-4ff02c5.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/jTypeWriter-1.1.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/bigtext-0.1.8.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/zoomline-0.0.1.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/highlight.pack-9.2.0.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/mermaid-6.0.0-min.js"></script>
 

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -9,8 +9,10 @@
 
   <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
   <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/font-awesome-4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/zoomline-0.0.1.css">
 
   <script type="text/javascript" src="<%= @asset_path %>/js/jquery-2.1.4.min.js"></script>
+  <script type="text/javascript" src="<%= @asset_path %>/js/zoomline-0.0.1.js"></script>
 
   <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js?v=<%= SHOWOFF_VERSION %>"></script>
 

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -3,68 +3,53 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <%= erb :header_mini %>
-
-    <script type="text/javascript">
-        $(document).ready(function(){ setupStats(); });
-    </script>
 </head>
 
 <body id="stats">
   <div id="wrapper">
+
+    <script type="text/javascript">
+        $(document).ready(function(){
+          $.getJSON("/stats_data", function( json ) {
+            setupStats(json);
+          });
+        });
+    </script>
+
     <h1>Viewing Statistics</h1>
-
-    <div id="least">
-      <h3>Least viewed slides</h3>
-      <% if @least.size > 0 %>
-        <% max = @least.sort_by {|slide, time| -time}[0][1].to_f %>
-        <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
-        <% @least.each do |slide, time| %>
-          <div class="row">
-            <span class="label"><%= slide %></span>
-            <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
-            <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-
-    <div id="most">
-      <h3>Most viewed slides</h3>
-      <% if @least.size > 0 %>
-        <% max = @most[0][1].to_f %>
-        <% timestr =  (max > 3599) ?  '%H:%M:%S' : '%M:%S' %>
-        <% @most.each do |slide, time| %>
-          <div class="row">
-            <span class="label"><%= slide %></span>
-            <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
-            <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-
-    <div id="all">
-      <h3>All slides</h3>
-      <%# We reuse the max value calculated from the above step. %>
-      <% @all.sort.map do |slide, time| %>
-          <div class="row">
-          <span class="label"><%= slide %></span>
-          <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
-          <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
-          <% if @counter %>
-            <div class="detail">
-              <% @counter[slide].each do |host, count| %>
-                <div class="row">
-                  <span class="label"><%= host %>:</span>
-                  <div class="bar" style="width: <%= (count/max)*100 %>%;"> </div>
-                  <div class="time"><%= Time.at(count).gmtime.strftime(timestr) %></div>
-                </div>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
+    <p id="stray"><span class="label"></span> of your audience is not viewing the same slide you are.</p>
+    <h2>Slides currently being viewed:</h2>
+    <div id="viewers">No data to display.</div>
+    <h2>Elapsed time spent on each slide:</h2>
+    <div id="elapsed">No data to display.</div>
   </div>
+
+  <div id="all">
+    <h3>All slides</h3>
+    <% max = @all.sort_by {|slide, time| -time}[0][1].to_f %>
+    <% @all.sort.map do |slide, time| %>
+        <% next if slide.empty? %>
+        <% timestr = (time < 60) ? ':%S' : (time < 3599) ?  '%M:%S' : '%H:%M:%S' %>
+        <div class="row top">
+        <span class="label"><%= slide %></span>
+        <div class="bar" style="width: <%= (time/max)*100 %>%;"> </div>
+        <div class="time"><%= Time.at(time).gmtime.strftime(timestr) %></div>
+        <% if @counter %>
+          <div class="detail">
+            <% @counter[slide].each do |host, views| %>
+              <% count = views.inject(0) { |sum, view| sum += view['elapsed'] } %>
+              <% timestr = (count < 60) ? ':%S' : (count < 3599) ?  '%M:%S' : '%H:%M:%S' %>
+              <div class="row">
+                <span class="label"><%= host %>:</span>
+                <div class="bar" style="width: <%= (count/max)*100 %>%;"> </div>
+                <div class="time"><%= Time.at(count).gmtime.strftime(timestr) %></div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
The datadump of the old viewstats menu didn't help anyone. Instead, this
shows an interactive sparkline graph of what the audience is currently
looking at and another graph of elapsed time for all slides.

This makes it trivial to visualize how you're capturing their attention
and makes it clear when you should revisit some topics.

I didn't spend a whole ton of time on graphical styling, since you're in
the middle of the restyle. Also, it looks a lot more interesting when there
are more than one to two clients!

Features:

* Highlights the menu button when more than 25% of the audience isn't
  following along.
* Click on the bars to navigate the presenter to that slide.
* Hover a bar to see its title and how many people are on it, or the
  total elapsed time on it.
* Open in new page to see full details of the elapsed time. This is the
  old "all" view. I didn't really do anything to it because I don't know
  that I think it's worth keeping around.
* Menu live updates every 30 seconds.
* Graphs zoom the bar on hover when it's too small to click. (it's still
  kind of a pain on the elapsed time graph, so it could use some love.)
* Graph is plain html, fully stylable and works even on IE.

<img width="620" alt="screen shot 2017-01-22 at 12 16 05 pm" src="https://cloud.githubusercontent.com/assets/1392917/22185811/3dda1e8c-e0a1-11e6-9c91-94f0829b7f01.png">