### PR TITLE
Prevent system from sleeping while presentation running

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'showoff'
 require 'showoff/version'
 require 'rubygems'
+require 'fidget'
 require 'gli'
 
 # See https://github.com/davetron5000/gli/issues/196 for rationale for this silly wrapper
@@ -98,24 +99,24 @@ module Wrapper
   arg_name 'heroku_name'
   long_desc 'Creates the configuration files needed to Herokuize a Showoff presentation and then deploys it for you.'
   command :heroku do |c|
-  
+
     c.desc 'add password protection to your heroku site'
     c.flag [:p,:password]
-  
+
     c.desc 'force overwrite of existing Gemfile/.gems and config.ru files if they exist'
     c.switch [:f,:force]
-  
+
     c.action do |global_options,options,args|
       raise "heroku_name is required" if args.empty?
       raise "Name must start with a letter and can only contain lowercase letters, numbers, and dashes." unless args.first =~ /^[a-z][a-z1-9-]*$/
-  
+
       unless system('git remote get-url heroku')
         ShowOffUtils.command("heroku create #{args[0]}", "Please ensure that the heroku gem is installed and you're logged in.")
       end
-  
+
       if ShowOffUtils.heroku(args[0],options[:f],options[:p])
         ShowOffUtils.command('bundle install', 'Please ensure that the bundler gem is installed.')
-  
+
         begin
           ShowOffUtils.command('git add Procfile Gemfile Gemfile.lock config.ru')
           ShowOffUtils.command('git commit -m "Herokuized by Showoff"')
@@ -129,11 +130,11 @@ module Wrapper
           puts
           puts 'When done, please run "git push heroku master"'
         end
-  
+
         if options[:p]
           puts "CAREFUL: you are commiting your access password - anyone with read access to the repo can access the preso\n\n"
         end
-  
+
         puts 'Your presentation has been Herokuized. Run `heroku open` to see it.'
       end
     end
@@ -221,6 +222,7 @@ module Wrapper
   -------------------------
 
   Your ShowOff presentation is now starting up.
+   **** System sleep has been suspended. ****
 
   To view it plainly, visit [ #{url} ]
 
@@ -230,6 +232,7 @@ module Wrapper
 
   "
 
+      Fidget.current_process
       if options[:url]
         ShowOffUtils.clone(options[:git_url], options[:git_branch], options[:git_path]) do
           ShowOff.run!(options) do |server|

--- a/bin/showoff
+++ b/bin/showoff
@@ -160,6 +160,9 @@ module Wrapper
     c.desc 'Disable content caching'
     c.switch :nocache
 
+    c.desc 'Prevent the computer from sleeping during your presentation'
+    c.switch :nosleep
+
     c.desc 'Port on which to run'
     c.default_value "9090"
     c.flag [:p, :port]
@@ -222,7 +225,6 @@ module Wrapper
   -------------------------
 
   Your ShowOff presentation is now starting up.
-   **** System sleep has been suspended. ****
 
   To view it plainly, visit [ #{url} ]
 
@@ -232,7 +234,11 @@ module Wrapper
 
   "
 
-      Fidget.current_process(:all)
+      if options[:nosleep] and Fidget.current_process
+        puts '**** System sleep has been suspended. ****'
+        puts
+      end
+
       if options[:url]
         ShowOffUtils.clone(options[:git_url], options[:git_branch], options[:git_path]) do
           ShowOff.run!(options) do |server|

--- a/bin/showoff
+++ b/bin/showoff
@@ -232,7 +232,7 @@ module Wrapper
 
   "
 
-      Fidget.current_process
+      Fidget.current_process(:all)
       if options[:url]
         ShowOffUtils.clone(options[:git_url], options[:git_branch], options[:git_path]) do
           ShowOff.run!(options) do |server|

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "sinatra", "~> 1.3"
   s.add_dependency      "gli",     ">= 2.0"
   s.add_dependency      "tilt",    ">= 2.0.3"
+  s.add_dependency      "fidget",  ">= 0.0.3"
   s.add_dependency      "json"
   s.add_dependency      "parslet"
   s.add_dependency      "htmlentities"


### PR DESCRIPTION
This uses my `fidget` gem to prevent the OS from sleeping while a
presentation is running. It will do the needful for OSX, Windows, and
most Linux systems.

I'm not convinced we want to do this unilaterally. Should there be a (yet another) CLI flag to enable it? Is this outside the scope of the project?