### PR TITLE
This allows the links to work in the PDF files too

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -652,7 +652,7 @@ class ShowOff < Sinatra::Application
             next if element['class'].nil?
             next unless element['class'].split.include? 'content'
 
-            href = element.attr('ref')
+            href = element.attr('ref').gsub('/', '_')
           end
 
           text   = item.attr('data-text')

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -448,6 +448,10 @@ function currentSlideFromName(name) {
   var count = 0;
   if(name.length > 0 ) {
   	slides.each(function(s, slide) {
+      if (name == $(slide).attr("id") ) {
+        found = count;
+        return false;
+      }
   	  if (name == $(slide).find(".content").attr("ref") ) {
   	    found = count;
   	    return false;


### PR DESCRIPTION
For them to work in a PDF, they need to be actual targets in the
document, and not just fragments that Showoff knows how to parse. This
teaches Showoff how to parse the snake-cased IDs too, and then converts
all hrefs to use them.