### PR TITLE
Switches internal client indexing to GUID

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -960,6 +960,7 @@ form .element {
 }
 #stats div#all div.bar {
   background: #66b366;
+  border-color: #000;
 }
 
 /* detail view */

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -40,8 +40,13 @@
               <% count = views.inject(0) { |sum, view| sum += view['elapsed'] } %>
               <% timestr = (count < 60) ? ':%S' : (count < 3599) ?  '%M:%S' : '%H:%M:%S' %>
               <div class="row">
-                <span class="label"><%= host %>:</span>
-                <div class="bar" style="width: <%= (count/max)*100 %>%;"> </div>
+                <% if host == 'presenter' %>
+                  <% bgcolor = '' %>
+                  <span class="label"><%= host %>:</span>
+                <% else %>
+                  <% bgcolor = "background-color: ##{host[0...6]}" %>
+                <% end %>
+                <div class="bar" style="width: <%= (count/max)*100 %>%; <%= bgcolor %>"> </div>
                 <div class="time"><%= Time.at(count).gmtime.strftime(timestr) %></div>
               </div>
             <% end %>


### PR DESCRIPTION
Prior to this it was using IP address, which made it unreliable when
clients were behind a proxy or the like. This also makes it easier to
test, since different browsers on a developer's machine will show up as
different connections.

This is visible to the presenter in the stats presentation and the forms
answers.

Fixes #539