### PR TITLE
Add an idle indicator

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -912,14 +912,20 @@ form .element {
 }
 
 
-#stats #stray {
+#stats #stray,
+#stats #idle {
   display: none;
   width: 75%;
   margin: 1em auto;
   padding: 0.5em;
   border: 1px solid #ccc;
-  background-color: #8e030a;
 }
+  #stats #stray {
+    background-color: #8e030a;
+  }
+  #stats #idle {
+    background-color: #3a64c1;
+  }
 
 /* style all three boxes */
 #stats div#least,

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1642,14 +1642,18 @@ function setupStats(data)
       $(this).find("div.detail").slideToggle("fast");
   });
 
-  var percent = data['stray_p'];
-  if(percent > 25) {
-    $('#stray').show();
-    $('#stray .label').text(percent+'%');
-  }
-  else {
-    $('#stray').hide();
-  }
+  ['stray', 'idle'].forEach(function(stat){
+    var percent = data[stat+'_p'];
+    var selector = '#'+stat;
+
+    if(percent > 25) {
+      $(selector).show();
+      $(selector+' .label').text(percent+'%');
+    }
+    else {
+      $(selector).hide();
+    }
+  });
 
   var location = window.location.pathname == '/presenter' ? '#' : '/#';
   var viewers  = data['viewers'];

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -18,6 +18,7 @@
 
     <h1>Viewing Statistics</h1>
     <p id="stray"><span class="label"></span> of your audience is not viewing the same slide you are.</p>
+    <p id="idle"><span class="label"></span> of your audience is idle.</p>
     <h2>Slides currently being viewed:</h2>
     <div id="viewers">No data to display.</div>
     <h2>Elapsed time spent on each slide:</h2>


### PR DESCRIPTION
This will put a notice if more than 25% of the audience hasn't looked at
a slide in more than 5 minutes. This will be 100% of the audience during
longer slides, for example lab slides in the PL courseware in which the
slide may not change for 15 or 20 minutes.

This stat will not trigger the warning state on the toolbar button.