### PR TITLE
Make the flyout tab easier to click.

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -566,6 +566,9 @@
     display: inline;
     background-color: #ccc;
   }
+  #notes ul.section-selector:hover {
+    font-size: 1.5em;
+  }
   #notes ul.section-selector:hover li {
     display: inline;
   }


### PR DESCRIPTION
Just enlarges the tab bar on hover. Makes it actually possible to switch tabs easily. It doesn't disrupt the content, unless you add a ridiculous number of sections.

<img width="421" alt="screen shot 2017-02-13 at 11 47 28 pm" src="https://cloud.githubusercontent.com/assets/1392917/22919873/1c89b10e-f247-11e6-88a3-f23c7078616c.png">