### PR TITLE
Tightened styling of the annotations button.

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -28,14 +28,16 @@
 }
 
   #topbar a,
-  #topbar select {
+  #topbar select,
+  #topbar .ui-widget {
     text-decoration: none;
     color: #fff;
     background: #222222;
   }
 
   #topbar a:hover,
-  #topbar select:hover {
+  #topbar select:hover,
+  #topbar .ui-widget:hover {
     background-color: #555;
   }
 
@@ -69,13 +71,15 @@
     margin: 0 0 0 auto;
   }
 
-  #links a {
+  #links a,
+  #topbar .ui-widget {
     border: 1px solid #ccc;
     border-radius: 0.5em;
     padding: .35em;
   }
 
-  #links a.enabled {
+  #links a.enabled,
+  #topbar .ui-state-active {
     background-color: #003d96;
   }
   #links a.warning {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -59,34 +59,6 @@ pre code {
     overflow: auto;
   }
 
-  .ui-button {
-    color: inherit;
-    background-color: transparent;
-    border-radius: 0.5em;
-    padding: .35em;
-  }
-
-  .ui-state-active,
-  .ui-widget-content .ui-state-active,
-  .ui-widget-header .ui-state-active,
-  a.ui-button:active,
-  .ui-button:active,
-  .ui-button.ui-state-active:hover {
-    background-color: #555;
-    border: 1px solid #ccc;
-  }
-
-  .ui-state-hover,
-  .ui-widget-content .ui-state-hover,
-  .ui-widget-header .ui-state-hover,
-  .ui-state-focus, .ui-widget-content .ui-state-focus,
-  .ui-widget-header .ui-state-focus,
-  .ui-button:hover,
-  .ui-button:focus {
-    border: 1px solid #ccc;
-    background-color: #555;
-  }
-
   #preso,
   .slide {
     background: #fff;


### PR DESCRIPTION
This removes some extra styles from `showoff.css` and puts focused rules
into `presenter.css` that limits the scope to only the topbar. This also
makes all the topbar elements look consistent.

Fixes #670