### PR TITLE
Updated section format

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -362,11 +362,7 @@ function setupMenu() {
       sectionUL = '';
 
   slides.each(function(s, slide){
-    var slidePath = $(slide)
-      .find(".content")
-      .attr('ref')
-      .split('/')
-      .shift();
+    var slidePath = $(slide).attr('data-section');
     var headers = $(slide).children("h1, h2");
     var slideTitle = '';
     var content;


### PR DESCRIPTION
This allows the sections to be specified by name instead of just by the
directory the slide happens to live in. This lets you build a
presentation structure that doesn't necessarily map to your directory
structure.

This will load all existing formats. We can deprecate old format later.

This *should* be complete, but I'd like to do more testing before
releasing it to the wild.

Fixes #678