### PR TITLE
Correct missing TOC crash

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -625,7 +625,7 @@ class ShowOff < Sinatra::Application
         end
 
         # swap out the tag, if found, with the table of contents
-        doc.at('p:contains("~~~TOC~~~")').replace(toc)
+        doc.at('p:contains("~~~TOC~~~")').replace(toc) rescue nil
       end
 
       doc.css('.slide.glossary .content').each do |glossary|


### PR DESCRIPTION
If the presentation was configured with a TOC but didn't actually have one, it would crash with a nil exception. This handles that case.