### PR TITLE
resized nav hover

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -525,8 +525,8 @@ img#disconnected {
   display: none;
   position: absolute;
   overflow: hidden;
-  width: 1024px;
-  height: 768px;
+  width: 640px;
+  height: 500px;
   z-index: 99999;
   background-color: inherit;
   margin: 0px;


### PR DESCRIPTION
This makes the nav hover look much more like the actual slide.

It'ss not a great fix because I just eyeballed the ratio. We should come back to it and figure out why it's sizing funny.