### PR TITLE
add activity indicator to audience view

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -104,6 +104,7 @@ Some useful styles for each slide are listed below. Many of them can be combined
 [background-fit] Scales a background image to the largest size that both height and width are onscreen. The default is to completely fill the slide.
 [bigtext] This will enlarge all the contents of the slide to the maximum possible size. <em>Caution, this should only be used for slides with just a few words or short phrases!</em>
 [autoplay] If you've included videos on the slide, this style will cause them to play when you switch to this slide.
+[activity] If you tag this slide as an <tt>activity</tt>, then audience members' presentations will get a toggle button on their slide, and their presentation will stop tracking along until they toggle it to complete. The presenter sees a count of all incompletes in the lower right of their slide preview.
 
 Check out the example directory included to see examples of most of these.
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -416,6 +416,7 @@ class ShowOff < Sinatra::Application
 
         content += sl
         content += "</div>\n"
+        content += '<i class="fa activity" aria-hidden="true"></i>' if content_classes.include? 'activity'
         content += "<canvas class=\"annotations\"></canvas>\n"
         content += "</div>\n"
 
@@ -1699,9 +1700,8 @@ class ShowOff < Sinatra::Application
                 @logger.debug "Recorded current slide #{slide} for #{remote}"
               end
 
-
             when 'position'
-              ws.send( { 'current' => @@current[:number] }.to_json ) unless @@cookie.nil?
+              ws.send( { 'message' => 'current', 'current' => @@current[:number] }.to_json ) unless @@cookie.nil?
 
             when 'pace', 'question', 'cancel'
               # just forward to the presenter(s) along with a debounce in case a presenter is registered twice

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -417,7 +417,12 @@ class ShowOff < Sinatra::Application
 
         content += sl
         content += "</div>\n"
-        content += '<i class="fa activity" aria-hidden="true"></i>' if content_classes.include? 'activity'
+        if content_classes.include? 'activity'
+          content += '<span class="activityToggle">'
+          content += "  <label for=\"activity-#{ref}\">Activity complete</label>"
+          content += "  <input type=\"checkbox\" class=\"activity\" name=\"activity-#{ref}\" id=\"activity-#{ref}\">"
+          content += '</span>'
+        end
         content += "<canvas class=\"annotations\"></canvas>\n"
         content += "</div>\n"
 
@@ -1713,7 +1718,7 @@ class ShowOff < Sinatra::Application
               @@activity[slide][remote] = status
 
               current  = @@current[:number]
-              activity = @@activity[current]
+              activity = @@activity[current] rescue nil
 
               @logger.debug "Current activity status: #{activity.inspect}"
               if activity

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -185,6 +185,7 @@ class ShowOff < Sinatra::Application
     @@cookie    = nil      # presenter cookie. Identifies the presenter for control messages
     @@current   = Hash.new # The current slide that the presenter is viewing
     @@cache     = nil      # Cache slide content for subsequent hits
+    @@activity  = []       # keep track of completion for activity slides
 
     if @interactive
       # flush stats to disk periodically
@@ -1702,6 +1703,24 @@ class ShowOff < Sinatra::Application
 
             when 'position'
               ws.send( { 'message' => 'current', 'current' => @@current[:number] }.to_json ) unless @@cookie.nil?
+
+            when 'activity'
+              next if valid_presenter_cookie?
+              remote = request.cookies['client_id']
+              slide  = control['slide']
+              status = control['status']
+              @@activity[slide] ||= {}
+              @@activity[slide][remote] = status
+
+              current  = @@current[:number]
+              activity = @@activity[current]
+
+              @logger.debug "Current activity status: #{activity.inspect}"
+              if activity
+                # select all activity on this slide where completion status is false
+                count = activity.select {|viewer, status| status == false }.size
+                EM.next_tick { settings.presenters.each{|s| s.send({ 'message' => 'activity', 'count' => count }.to_json) } }
+              end
 
             when 'pace', 'question', 'cancel'
               # just forward to the presenter(s) along with a debounce in case a presenter is registered twice

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -606,6 +606,7 @@
     width: 90%;
   }
 
+  .slide.activity .count,
   #notes .count {
     display: inline-block;
     background-color: #2e2e2e;
@@ -635,6 +636,13 @@
   #notes .pagebreak {
     display: none;
   }
+
+.slide.activity .count {
+  position: absolute;
+  bottom: .25em;
+  right: .5em;
+  padding: 0 0.25em;
+}
 
 
 a.controls {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1134,6 +1134,20 @@ a.term:after {
 ***  glossary       ***
 **********************/
 
+/**************************
+*** activity indicators ***
+***************************/
+.slide.activity i.activity:after {
+  position: absolute;
+  bottom: .25em;
+  right: .5em;
+  font-size: 3em;
+  content: "\f204";     /* fa-toggle-off */
+}
+.slide.activity i.activity.complete:after {
+  content: "\f205";     /* fa-toggle-on */
+}
+
 
 /* Render hidden headlines so that when we print with wkhtmltopdf, we can use section
    titles for page headers.  it would make sense to put this in the print section, but

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1137,6 +1137,9 @@ a.term:after {
 /**************************
 *** activity indicators ***
 ***************************/
+.slide.activity i.activity{
+  cursor: pointer;
+}
 .slide.activity i.activity:after {
   position: absolute;
   bottom: .25em;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1137,20 +1137,11 @@ a.term:after {
 /**************************
 *** activity indicators ***
 ***************************/
-.slide.activity i.activity{
-  cursor: pointer;
-}
-.slide.activity i.activity:after {
+.slide.activity .activityToggle {
   position: absolute;
-  bottom: .25em;
-  right: .5em;
-  font-size: 3em;
-  content: "\f204";     /* fa-toggle-off */
+  bottom: 1em;
+  right: 1em;
 }
-.slide.activity i.activity.complete:after {
-  content: "\f205";     /* fa-toggle-on */
-}
-
 
 /* Render hidden headlines so that when we print with wkhtmltopdf, we can use section
    titles for page headers.  it would make sense to put this in the print section, but

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -678,7 +678,7 @@ function postSlide() {
     });
 
     if(currentSlide.hasClass('activity')) {
-      currentSlide.children('i.activity').replaceWith('<span class="count">0</span>');
+      currentSlide.children('.activityToggle').replaceWith('<span class="count">0</span>');
     }
 	}
 }

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -535,6 +535,10 @@ function updatePace() {
   }
 }
 
+function updateActivityCompletion(count) {
+  currentSlide.children('.count').text(count);
+}
+
 // extend this function to add presenter bits
 var origGotoSlide = gotoSlide;
 gotoSlide = function (slideNum)
@@ -672,6 +676,10 @@ function postSlide() {
     $("#notes div.form.wrapper").each(function(e) {
       renderFormInterval = renderFormWatcher($(this));
     });
+
+    if(currentSlide.hasClass('activity')) {
+      currentSlide.children('i.activity').replaceWith('<span class="count">0</span>');
+    }
 	}
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -221,9 +221,10 @@ function initializePresentation(prefix) {
 
   // The display window doesn't need the extra chrome
   if(typeof(presenterView) != 'undefined') {
-    $('.slide.activity').removeClass('activity').children('i.activity').remove();
+    $('.slide.activity').removeClass('activity').children('.activityToggle').remove();
   }
-  $('.slide.activity i.activity').click(toggleComplete);
+  $('.slide.activity .activityToggle input.activity').checkboxradio();
+  $('.slide.activity .activityToggle input.activity').change(toggleComplete);
 
   // initialize mermaid, but don't render yet since the slide sizes are indeterminate
   mermaid.initialize({startOnLoad:false});
@@ -650,13 +651,18 @@ function showSlide(back_step, updatepv) {
   postSlide();
 
   // is this an activity slide that has not yet been marked complete?
-  if(currentSlide.hasClass('activity') && ! currentSlide.children('i.activity').hasClass('complete')) {
-    activityIncomplete = true;
-    sendActivityStatus(false);
+  if (currentSlide.hasClass('activity')) {
+     if (currentSlide.find('input.activity').is(":checked")) {
+      activityIncomplete = false;
+      sendActivityStatus(true);
+    }
+    else {
+      activityIncomplete = true;
+      sendActivityStatus(false);
+    }
   }
   else {
     activityIncomplete = false;
-    sendActivityStatus(true);
   }
 
   // make all bigly text tremendous
@@ -1394,9 +1400,7 @@ function getKeyName (event) {
 }
 
 function toggleComplete() {
-  $(this).toggleClass('complete');
-
-  if($(this).hasClass('complete')) {
+  if($(this).is(':checked')) {
     activityIncomplete = false;
     sendActivityStatus(true);
     if(mode.follow) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1404,6 +1404,7 @@ function toggleComplete() {
   }
   else {
     activityIncomplete = true;
+    sendActivityStatus(false);
   }
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -656,6 +656,7 @@ function showSlide(back_step, updatepv) {
   }
   else {
     activityIncomplete = false;
+    sendActivityStatus(true);
   }
 
   // make all bigly text tremendous

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -19,6 +19,7 @@ var lastMessageGuid = 0
 var query;
 var section = 'handouts'; // default to showing handout notes for display view
 var slideStartTime = new Date().getTime()
+var activityIncomplete = false; // slides won't advance when this is on
 
 var loadSlidesBool
 var loadSlidesPrefix
@@ -116,6 +117,8 @@ function setupPreso(load_slides, prefix) {
     },function() {
       $('#navigationHover').hide();
     });
+
+    $('.slide.activity i.activity').click(toggleComplete);
   });
 
   // Open up our control socket
@@ -642,6 +645,14 @@ function showSlide(back_step, updatepv) {
   // copy notes to the notes field for mobile.
   postSlide();
 
+  // is this an activity slide that has not yet been marked complete?
+  if(currentSlide.hasClass('activity') && ! currentSlide.children('i.activity').hasClass('complete')) {
+    activityIncomplete = true;
+  }
+  else {
+    activityIncomplete = false;
+  }
+
   // make all bigly text tremendous
   currentSlide.children('.content.bigtext').bigtext();
 
@@ -1114,7 +1125,7 @@ function editSlide() {
 }
 
 function follow(slide, newIncrement) {
-  if (mode.follow) {
+  if (mode.follow && ! activityIncomplete) {
     var lastSlide = slidenum;
     console.log("New slide: " + slide);
     gotoSlide(slide);
@@ -1358,6 +1369,20 @@ function getKeyName (event) {
     }
   }
   return keyName;
+}
+
+function toggleComplete() {
+  $(this).toggleClass('complete');
+
+  if($(this).hasClass('complete')) {
+    activityIncomplete = false;
+    if(mode.follow) {
+      getPosition();
+    }
+  }
+  else {
+    activityIncomplete = true;
+  }
 }
 
 function toggleDebug () {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -741,6 +741,10 @@ function submitForm(form) {
       var submit = form.find("input[type=submit]")
       submit.attr("disabled", "disabled");
       submit.removeClass("dirty");
+
+      // stop blocking follow mode
+      activityIncomplete = false;
+      getPosition();
     });
   }
 }
@@ -769,7 +773,10 @@ function validateForm(form) {
 function enableForm(element) {
   var submit = element.closest('form').find(':submit')
   submit.removeAttr("disabled");
-  submit.addClass("dirty")
+  submit.addClass("dirty");
+
+  // once a form is started, stop following the presenter
+  activityIncomplete = true;
 }
 
 function renderFormWatcher(element) {


### PR DESCRIPTION
This puts a toggle button on slides marked with `activity`. When the
toggle is off (activity incomplete), then the deck will not follow
the presenter slides until the viewer either toggles it on (activity
complete) or manually navigates away from the slide.

I am debating whether to add more to the audience widget. The more I play with it, the more I like it without a label.

The `1` in presenter here represents the number of audience members who have not marked themselves as complete yet, and the toggle on the audience slide is how they do so.

Note that the toggle does *not* show up on the projected display view.

<img width="933" alt="screen shot 2017-03-09 at 5 37 10 pm" src="https://cloud.githubusercontent.com/assets/1392917/23778472/4126a5c0-04ef-11e7-9ca1-5b2c14bb0dc3.png">


Fixes #700