### PR TITLE
Support simple classed divs in content

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -438,6 +438,9 @@ will behave just like <tt>showoff static print handouts</tt>.
   Places a continuously updating block displaying the live results from the form with the given ID.
   This is most useful when you're performing a poll or pop quiz during the presentation.
 
+[~~~DIV:class~~~]
+  Places content in a classed div to enable more complex layouts and styling.
+
 = Preshow
 
 If you want to show a slideshow while you wait to speak, you can run a preshow.

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -410,6 +410,7 @@ class ShowOff < Sinatra::Application
         sl = build_forms(sl, content_classes)
         sl = update_p_classes(sl)
         sl = process_content_for_section_tags(sl, name, opts)
+        sl = process_content_for_div_tags(sl, name, opts)
         sl = update_special_content(sl, @slide_count, name) # TODO: deprecated
         sl = update_image_paths(name, sl, opts)
 
@@ -468,7 +469,23 @@ class ShowOff < Sinatra::Application
       result
     end
 
-    # replace section tags with classed div tags
+    # Replace DIV tags with classed div tags
+    def process_content_for_div_tags(content, name = nil, opts = {})
+      return unless content
+
+      # because this is post markdown rendering, we may need to shift a <p> tag around
+      # remove the tags if they're by themselves
+      result = content.gsub(/<p>~~~DIV:([^~]*)~~~<\/p>/, '<div class="\1">')
+      result.gsub!(/<p>~~~ENDDIV~~~<\/p>/, '</div>')
+
+      # shove it around the div if it belongs to the contained element
+      result.gsub!(/(<p>)?~~~DIV:([^~]*)~~~/, '<div class="\2">\1')
+      result.gsub!(/~~~ENDDIV~~~(<\/p>)?/, '\1</div>')
+
+      result
+    end
+
+    # replace section tags with classed div tags including notes-section class
     def process_content_for_section_tags(content, name = nil, opts = {})
       return unless content
 


### PR DESCRIPTION
Following the pattern of ~~~SECTION~~~, etc. This PR adds support for
simple classed divs within the content section in order to support more
complex slide layouts.