### PR TITLE
hide pacer and questions if feedback is off

### DIFF
--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -64,6 +64,8 @@
         </span>
         <div id="timerDisplay"></div>
       </div>
+
+      <% if @feedback and not @static then %>
       <div id="feedbackPace">
         <div class="gradient"> </div>
         <div class="left obscure"> </div>
@@ -72,13 +74,19 @@
         <span id="paceFast">Slow Down!</span>
         <img id="paceMarker" src="<%= @asset_path %>/css/paceMarker.png" />
       </div>
+      <% end %>
+
       <div id="navigation" class="submenu"></div>
       <div id="navigationHover"></div>
+
+      <% if @feedback and not @static then %>
       <div id="questions">
         <h3>Audience Questions</h3>
         <ol id="unanswered"></ol>
         <ol id="answered"></ol>
       </div>
+      <% end %>
+
     </div>
 
     <div id="presenter">


### PR DESCRIPTION
Don't render the pace and questions elements in presenter view if feedback is disabled for the presentation.

![screen shot 2017-03-11 at 12 02 58 pm](https://cloud.githubusercontent.com/assets/3277190/23826529/bd1cae0e-0652-11e7-8e63-c1cdddb2f8c3.png)
