### PR TITLE
initialize control socket unconditionally

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -120,9 +120,8 @@ function setupPreso(load_slides, prefix) {
   });
 
   // Open up our control socket
-  if(mode.track) {
-    connectControlChannel();
-  }
+  connectControlChannel();
+
 }
 
 function loadSlides(load_slides, prefix, reload, hard) {


### PR DESCRIPTION
Other logic expects the `ws` object to exist to decide whether to send a message. The `connectControlChannel()` function will initialize it to either a socket, or an empty dummy object based on settings.

This will prevent presentations generated with `static` from crashing.