### PR TITLE
Add single line hightlighting

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -207,6 +207,14 @@ will become sparkly and colorful. You can uppercase the name if you like.
     @@@ Ruby
     10.times { puts "Whee!" }
 
+To highlight a specific line in your snippet of code, simply prefix it with a <tt>*</tt>.
+
+    @@@ Ruby execute
+    ['one', 'two', 'three'].collect do |item|
+      puts item
+    *  puts item.upcase  # This line will be highlighted to call attention to it
+    end
+
 Supported languages include:
 
     1c             dts            livescript     ruby

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1457,10 +1457,10 @@ class ShowOff < Sinatra::Application
         classes = code.attr('class').split rescue []
         lang    = classes.shift =~ /language-(\S*)/ ? $1 : nil
 
-        [lang, code.text, classes]
+        [lang, code.text.gsub(/^\* /, ' '), classes]
       end
     else
-      doc.css(classes)[index.to_i].text rescue 'Invalid code block index'
+      doc.css(classes)[index.to_i].text.gsub(/^\* /, ' ') rescue 'Invalid code block index'
     end
   end
 

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -577,6 +577,12 @@ pre.highlight code.language-powershellconsole.nochrome {
   border-radius: 4px;
 }
 
+pre.highlight code .highlightedLine {
+  background-color: #f5e2e2;
+  display: inline-block;
+  width: 100%;
+}
+
 /* to avoid breaking changes */
 .highlight .language-shell {
   display: block;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -183,6 +183,16 @@ function initializePresentation(prefix) {
   $('pre.highlight code').each(function(i, block) {
     try {
       hljs.highlightBlock(block);
+
+      // Highlight requested lines
+      block.innerHTML = block.innerHTML.split(/\r?\n/).map(function (line, i) {
+        if (line.indexOf('* ') === 0) {
+          return line.replace(/^\*(.*)$/, '<div class="highlightedLine">$1</div>');
+        }
+
+        return line;
+      }).join('\n');
+
     } catch(e) {
       console.log('Syntax highlighting failed on ' + $(this).closest('div.slide').attr('id'));
       console.log('Syntax highlighting failed for ' + $(this).attr('class'));


### PR DESCRIPTION
This allows you to highlight a line of text inside a code block by
prefixing it with a `*`. This has been tested in content viewing, code
execution, and code validation.

Fixes #701