### PR TITLE
Corrects menu display on Firefox

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -382,6 +382,10 @@ img#disconnected {
   margin-right: 8px;
 }
 
+.sideMenu hr {
+  clear: both;
+}
+
 .buttonWrapper {
   line-height: 48px;
   padding: 0 16px;


### PR DESCRIPTION
Because of the floated elements, the bounding box of items below underlapped the buttons.

![screen shot 2017-03-20 at 1 17 03 pm](https://cloud.githubusercontent.com/assets/1392917/24119842/c1dee0be-0d6f-11e7-8fd8-2a78d4d181b3.png)