### PR TITLE
Internationalization

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -304,6 +304,9 @@ module Wrapper
     c.default_value "showoff.json"
     c.flag [:f, :file, :pres_file]
 
+    c.desc 'Language code to generate.'
+    c.flag [:l, :lang, :language, :locale]
+
     c.action do |global_options,options,args|
       ShowOff.do_static(args, options)
     end

--- a/documentation/INTERNATIONALIZATION.rdoc
+++ b/documentation/INTERNATIONALIZATION.rdoc
@@ -1,0 +1,52 @@
+= Internationalization
+
+Showoff transparently supports both user interface localization and content
+translation.  Each user will see UI elements and content translated to the
+language their web browser is set to, assuming the proper translation exists.
+
+== User Interface
+
+The Showoff user interface, such as the sidebar menu and help dialog,will
+automatically localize itself to the language of the viewer. The list of
+supported languages can be seen in the
+{repository}[http://puppetlabs.github.io/https://github.com/puppetlabs/showoff/tree/master/locales].
+No configuration is required.
+
+If you'd like to contribute a translation file, please follow the
+{directions provided}[http://puppetlabs.github.io/https://github.com/puppetlabs/showoff/tree/master/locales/README.md].
+
+== Content Translation
+
+Showoff will present each user with content in the language of their choice.
+It is the author's job to create the translations in the first place.
+
+When the presentation is loaded, Showoff matches the language setting of the
+user's browser against the <tt>locales</tt> directory. If it finds a subdirectory
+matching the language, or one of the fallbacks, then that content will be served.
+
+For example, if the user's browser was set to <tt>en-GB</tt>, then Showoff would
+look for these directories in order:
+
+* <tt>locales/en-GB</tt>
+* <tt>locales/en</tt>
+* default to main presentation directory
+
+The structure of the translated presentation directory should match *exactly*
+the structure of the top-level default presentation. The same relative paths
+will be used to reference each slide.
+
+Images or other media should also be located in the localized directory. This
+allows you to translate any images with text as well. If you don't need this,
+you can symlink the directory, or you can use relative parent paths
+(<tt>../../</tt>) to point to the correct images.
+
+== Browser Configuration
+
+The language that Showoff selects is determined by the end-user browser settings.
+In other words, if the user wants to see Spanish content, they should configure
+their browser to prefer Spanish.
+
+Each browser is configured somewhat differently. For example, the language
+selection for Safari on macOS lives in the OS system preferences. On the other
+hand, Chrome has built-in language selection underneath the *Advanced* section
+of the settings and Firefox puts it under the *Content* section.

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1227,20 +1227,12 @@ class ShowOff < Sinatra::Application
     end
 
     def slides(static=false)
-<<<<<<< HEAD
       @logger.warn "Cached presentations: #{@@cache.keys}"
-=======
-      @logger.debug "Cached presentations: #{@@cache.keys}"
->>>>>>> 992e55c11e9bc224475ade811007f406279f3861
 
       # if we have a cache and we're not asking to invalidate it
       return @@cache[@locale] if (@@cache[@locale] and params['cache'] != 'clear')
 
-<<<<<<< HEAD
       @logger.warn "Generating locale: #{@locale}"
-=======
-      @logger.debug "Generating locale: #{@locale}"
->>>>>>> 992e55c11e9bc224475ade811007f406279f3861
 
       # If we're displaying from a repository, let's update it
       ShowOffUtils.update(settings.verbose) if settings.url

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -271,6 +271,12 @@ class ShowOff < Sinatra::Application
       end
     end
 
+    def get_translations
+      languages = I18n.backend.send(:translations)
+      fallback  = I18n.fallbacks[I18n.locale].select { |f| languages.keys.include? f }.first
+      languages[fallback]
+    end
+
     # todo: move more behavior into this class
     class Slide
       attr_reader :classes, :text, :tpl, :bg
@@ -1131,7 +1137,7 @@ class ShowOff < Sinatra::Application
       @edit     = settings.showoff_config['edit'] if @review
 
       # translated UI strings, according to the current locale
-      @language = I18n.backend.send(:translations)[I18n.locale]
+      @language = get_translations()
 
       # store a cookie to tell clients apart. More reliable than using IP due to proxies, etc.
       if request.nil?   # when running showoff static
@@ -1153,7 +1159,7 @@ class ShowOff < Sinatra::Application
       @issues    = settings.showoff_config['issues']
       @edit      = settings.showoff_config['edit'] if @review
       @feedback  = settings.showoff_config['feedback']
-      @language  = I18n.backend.send(:translations)[I18n.locale]
+      @language  = get_translations()
       @@cookie ||= guid()
       response.set_cookie('presenter', @@cookie)
       erb :presenter

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -8,8 +8,11 @@ require 'logger'
 require 'htmlentities'
 require 'sinatra-websocket'
 require 'tempfile'
+
 require 'i18n'
 require 'i18n/backend/fallbacks'
+require 'rack'
+require 'rack/contrib'
 
 here = File.expand_path(File.dirname(__FILE__))
 require "#{here}/showoff_utils"
@@ -55,10 +58,14 @@ class ShowOff < Sinatra::Application
   set :encoding, nil
   set :url, nil
 
+  # automatically select the translation based on the user's configured browser language
+  use Rack::Locale
+
   configure do
     I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
     I18n.load_path += Dir[File.join(settings.root, '..', 'locales', '*.yml')]
     I18n.backend.load_translations
+    I18n.enforce_available_locales = false
   end
 
   def initialize(app=nil)
@@ -70,10 +77,6 @@ class ShowOff < Sinatra::Application
     @review  = settings.review
     @execute = settings.execute
 
-    dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-    @logger.debug(dir)
-
-    showoff_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
     settings.pres_dir ||= Dir.pwd
     @root_path = "."
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -430,7 +430,7 @@ class ShowOff < Sinatra::Application
         content += "</div>\n"
         if content_classes.include? 'activity'
           content += '<span class="activityToggle">'
-          content += "  <label for=\"activity-#{ref}\">Activity complete</label>"
+          content += "  <label for=\"activity-#{ref}\">#{I18n.t('activity_complete')}</label>"
           content += "  <input type=\"checkbox\" class=\"activity\" name=\"activity-#{ref}\" id=\"activity-#{ref}\">"
           content += '</span>'
         end

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1401,6 +1401,8 @@ class ShowOff < Sinatra::Application
       path = showoff.instance_variable_get(:@root_path)
       logger = showoff.instance_variable_get(:@logger)
 
+      I18n.locale = opts[:language]
+
       case what
       when 'supplemental'
         data = showoff.send(what, opt, true)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1072,7 +1072,7 @@ class ShowOff < Sinatra::Application
 
     def get_slides_html(opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil, :section=>nil})
       sections = nil
-      Dir.chdir(get_locale_dir('locale')) do
+      Dir.chdir(get_locale_dir('locales')) do
         sections = ShowOffUtils.showoff_sections(settings.pres_dir, settings.showoff_config, @logger)
       end
 
@@ -1227,12 +1227,12 @@ class ShowOff < Sinatra::Application
     end
 
     def slides(static=false)
-      @logger.debug "Cached presentations: #{@@cache.keys}"
+      @logger.warn "Cached presentations: #{@@cache.keys}"
 
       # if we have a cache and we're not asking to invalidate it
       return @@cache[@locale] if (@@cache[@locale] and params['cache'] != 'clear')
 
-      @logger.debug "Generating locale: #{@locale}"
+      @logger.warn "Generating locale: #{@locale}"
 
       # If we're displaying from a repository, let's update it
       ShowOffUtils.update(settings.verbose) if settings.url
@@ -1838,7 +1838,8 @@ class ShowOff < Sinatra::Application
 
   # gawd, this whole routing scheme is bollocks
   get %r{/([^/]*)/?([^/]*)} do
-    @title = ShowOffUtils.showoff_title(settings.pres_dir)
+    @locale    = locale()
+    @title     = ShowOffUtils.showoff_title(settings.pres_dir)
     @pause_msg = ShowOffUtils.pause_msg
     what = params[:captures].first
     opt  = params[:captures][1]

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -275,7 +275,7 @@ class ShowOff < Sinatra::Application
     # to cwd. This works similarly to I18n fallback, but we cannot reuse that as it's
     # a different translation mechanism.
     def get_locale_dir(prefix)
-      locale = I18n.locale
+      locale = I18n.locale.to_s
 
       until (locale.empty?) do
         path = "#{prefix}/#{locale}"

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -8,6 +8,8 @@ require 'logger'
 require 'htmlentities'
 require 'sinatra-websocket'
 require 'tempfile'
+require 'i18n'
+require 'i18n/backend/fallbacks'
 
 here = File.expand_path(File.dirname(__FILE__))
 require "#{here}/showoff_utils"
@@ -52,6 +54,12 @@ class ShowOff < Sinatra::Application
   set :showoff_config, {}
   set :encoding, nil
   set :url, nil
+
+  configure do
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    I18n.load_path += Dir[File.join(settings.root, '..', 'locales', '*.yml')]
+    I18n.backend.load_translations
+  end
 
   def initialize(app=nil)
     super(app)
@@ -139,7 +147,7 @@ class ShowOff < Sinatra::Application
     @slide_count   = 0
     @section_major = 0
     @section_minor = 0
-    @section_title = settings.showoff_config['name'] rescue 'Showoff Presentation'
+    @section_title = settings.showoff_config['name'] rescue I18n.t('name')
     @@slide_titles  = [] # a list of generated slide names, used for cross references later.
 
     @logger.debug settings.pres_template
@@ -514,7 +522,7 @@ class ShowOff < Sinatra::Application
         doc.add_child '<div class="notes-section notes"></div>' if doc.css('div.notes-section.notes').empty?
         doc.css('div.notes-section.notes').each do |section|
           text = Tilt[:markdown].new(nil, nil, engine_options) { File.read(filename) }.render
-          frag = "<div class=\"personal\"><h1>Personal Notes</h1>#{text}</div>"
+          frag = "<div class=\"personal\"><h1>#{I18n.t('presenter.notes.personal')}</h1>#{text}</div>"
           note = Nokogiri::HTML::DocumentFragment.parse(frag)
 
           if section.children.size > 0
@@ -725,8 +733,8 @@ class ShowOff < Sinatra::Application
 
       begin
         tools =  '<div class="tools">'
-        tools << '<input type="button" class="display" value="Display Results">'
-        tools << '<input type="submit" value="Save" disabled="disabled">'
+        tools << "<input type=\"button\" class=\"display\" value=\"#{I18n.t('forms.display')}\">"
+        tools << "<input type=\"submit\" value=\"#{I18n.t('forms.save')}\" disabled=\"disabled\">"
         tools << '</div>'
         form  = "<form id='#{title}' action='/form/#{title}' method='POST'>#{content}#{tools}</form>"
         doc = Nokogiri::HTML::DocumentFragment.parse(form)
@@ -1112,6 +1120,9 @@ class ShowOff < Sinatra::Application
       # Provide a button in the sidebar for interactive editing if configured
       @edit     = settings.showoff_config['edit'] if @review
 
+      # translated UI strings, according to the current locale
+      @language = I18n.backend.send(:translations)[I18n.locale]
+
       # store a cookie to tell clients apart. More reliable than using IP due to proxies, etc.
       if request.nil?   # when running showoff static
         @client_id = guid()
@@ -1131,6 +1142,8 @@ class ShowOff < Sinatra::Application
       @favicon   = settings.showoff_config['favicon']
       @issues    = settings.showoff_config['issues']
       @edit      = settings.showoff_config['edit'] if @review
+      @feedback  = settings.showoff_config['feedback']
+      @language  = I18n.backend.send(:translations)[I18n.locale]
       @@cookie ||= guid()
       response.set_cookie('presenter', @@cookie)
       erb :presenter

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -476,11 +476,16 @@ class ShowOffUtils
 
       # Normalize to a proper path from presentation root
       filename = File.expand_path(entry).sub(/^#{dir}\//, '')
+      # and then strip out the locale directory, if there is one
+      filename.sub!(/^(locales\/[\w-]+\/)/, '')
+      locale = $1
+
       if File.directory? filename
         path = entry
         sections[path] ||= []
         Dir.glob("#{filename}/**/*.md").sort.each do |slidefile|
-          sections[path] << slidefile
+          fullpath = locale.nil? ? slidefile : "#{locale}/#{slidefile}"
+          sections[path] << fullpath
         end
       else
         path = File.dirname(entry)

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -391,24 +391,28 @@ class ShowOffUtils
     [code,lines,width]
   end
 
-  def self.showoff_sections(dir, logger = nil)
+  def self.showoff_sections(dir, data = nil, logger = nil)
     unless logger
       logger = Logger.new(STDOUT)
       logger.level = Logger::WARN
     end
 
-    index = File.join(dir, ShowOffUtils.presentation_config_file)
     begin
-      data = JSON.parse(File.read(index)) rescue ["."] # default boring showoff.json
+      unless data
+        index = File.join(dir, ShowOffUtils.presentation_config_file)
+        data  = JSON.parse(File.read(index)) rescue ["."] # default boring showoff.json
+      end
+
       logger.debug data
       if data.is_a?(Hash)
-        sections = data['sections'] if data.include? 'sections'
+        # dup so we don't overwrite the original data structutre and make it impossible to re-localize
+        sections = data['sections'].dup
       else
-        sections = data
+        sections = data.dup
       end
 
       if sections.is_a? Array
-        sections = showoff_legacy_sections(sections)
+        sections = showoff_legacy_sections(dir, sections)
       elsif sections.is_a? Hash
         raise "Named sections are unsupported on Ruby versions less than 1.9." if RUBY_VERSION.start_with? '1.8'
         sections.each do |key, value|
@@ -437,7 +441,7 @@ class ShowOffUtils
     sections
   end
 
-  def self.showoff_legacy_sections(data)
+  def self.showoff_legacy_sections(dir, data)
     # each entry in sections can be:
     # - "filename.md"
     # - { "section": "filename.md" }
@@ -465,28 +469,31 @@ class ShowOffUtils
           end
         end
       end
-
       section
-    end.flatten.compact.each do |filename|
+    end.flatten.compact.each do |entry|
       # We do this in two passes simply because most of it was already done
       # and I don't want to waste time on legacy functionality.
+
+      # Normalize to a proper path from presentation root
+      filename = File.expand_path(entry).sub(/^#{dir}\//, '')
       if File.directory? filename
-        path = filename
+        path = entry
         sections[path] ||= []
         Dir.glob("#{filename}/**/*.md").sort.each do |slidefile|
           sections[path] << slidefile
         end
       else
-        path = File.dirname(filename)
+        path = File.dirname(entry)
         sections[path] ||= []
         sections[path]  << filename
       end
     end
+
     sections
   end
 
-  def self.showoff_slide_files(dir, logger = nil)
-    data = showoff_sections(dir, logger)
+  def self.showoff_slide_files(dir, data = nil, logger = nil)
+    data = showoff_sections(dir, data, logger)
     data.map { |key, value| value }.flatten
   end
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -6,7 +6,7 @@ update an existing one.
 
 ## Generating a new strings file
 
-1. Copy `en.yml` to a new file named after the language.
+1. Copy `en.yml` to a new file in the `locales` directory named after the language.
     * Use the two-letter [ISO_639-1](https://en.wikipedia.org/wiki/ISO_639-1) code.
     * The extension *must be* `.yml`; for example `de.yml`.
 1. Translate each value without changing the file structure.

--- a/locales/README.md
+++ b/locales/README.md
@@ -14,8 +14,6 @@ update an existing one.
 1. Translate each value without changing the file structure.
     * Quotes around the string are not necessary unless it contains a special character, such as `:`
 1. Submit a PR with your new language!
-    * Make sure you submit it against the `internationalization` branch!
-    * This isn't being merged to `master` until it's complete.
 
 ## Using the GitHub web UI
 

--- a/locales/README.md
+++ b/locales/README.md
@@ -9,6 +9,8 @@ update an existing one.
 1. Copy `en.yml` to a new file in the `locales` directory named after the language.
     * Use the two-letter [ISO_639-1](https://en.wikipedia.org/wiki/ISO_639-1) code.
     * The extension *must be* `.yml`; for example `de.yml`.
+1. Change the toplevel key from `:en` to the language code as a symbol.
+    * For example, `:de` or `:es`.
 1. Translate each value without changing the file structure.
     * Quotes around the string are not necessary unless it contains a special character, such as `:`
 1. Submit a PR with your new language!

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,0 +1,25 @@
+# Creating a strings file for a new translation
+
+Thanks for helping translate. It's a big job. Your part should be fairly
+simple though. All you'll need to do is generate a new strings file, or
+update an existing one.
+
+## Generating a new strings file
+
+1. Copy `en.yml` to a new file named after the language.
+    * Use the two-letter [ISO_639-1](https://en.wikipedia.org/wiki/ISO_639-1) code.
+    * The extension *must be* `.yml`; for example `de.yml`.
+1. Translate each value without changing the file structure.
+    * Quotes around the string are not necessary unless it contains a special character, such as `:`
+1. Submit a PR with your new language!
+    * Make sure you submit it against the `internationalization` branch!
+    * This isn't being merged to `master` until it's complete.
+
+## Using the GitHub web UI
+
+It might be easiest to just do this in the GitHub UI if you don't already have
+your own fork & clone of the project.
+
+Copying a file isn't very straightforward in the web UI. Instead, you'll need to
+copy the file contents to your clipboard, then create a new file and paste it back
+in. Nevertheless, once the file's created, it's quite easy to update this way.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -129,7 +129,7 @@ de:
         tooltip: Aktiviert das Update durch einen weiteren Präsentierer.
         description: Wenn dies aktiviert ist, dann kann man die Präsentationvon einem anderen Geräterfolgen (üblicherweise ein Mobiles Endegerät).
       layout:
-        label: Aktualisierung der Schüler
+        label: Anordnung
         default: Default Ansicht
         thumbs: Anzeigen von Miniaturansichten der nächsten und vorherigen Folie.
         beside: Anzeigen der nächsten Folie als Großansicht n der Präsentierer Ansicht.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -1,0 +1,145 @@
+de:
+  name: Showoff Präsentation
+  menu:
+    title: Showoff Menü
+    table_of_contents: Inhaltsverzeichnis
+    downloads: Downloads
+    feedback: Senden...
+    pace:
+      label: Der Präsentierende soll...
+      slower: Langsamer werden
+      faster: Schneller werden
+    question:
+      label: XFrage stellen
+      placeholder: Frage stellen...
+    feedback:
+      label: Feedback senden
+      description: Diese Folie ist...
+      worst: Schrecklich
+      best: Großartig
+      why: Warum...?
+      send: Senden
+    edit: Aktuelle Folie ändern
+    clear_annotations: Anmerkungen entfernen
+    close: Schließen
+    help: Drücke das <code>?</code> für Hilfe.
+    anonymous: Alle Feedbacks sind anonym.
+  navigation:
+    next: Nächste Folie
+    previous: Vorherige Folie
+  loading: laden der Präsentation...
+  activity_complete: Aktivität vollständig
+  follow:
+    label: "Folge dem Präsentierer:"
+  refresh: "Soll der Inhalt der Folie aktualisiert werden?\n\n(Verwende `RELOAD` wenn die gesamte Präsentation neu geladen werden soll)"
+  reload: Soll Showoff neu geladen werden?
+  preshow:
+    prompt: Beginn in Minuten?
+    resume: "Fortsetzen in Minuten:"
+
+  downloads:
+    title: Datei Downloads
+
+  help:
+    title: Hilfe
+    next: Zur nächsten Folie.
+    prev: Zur vorherigen Folie.
+    contents: Anzeigen des Inhaltsverzeichnisses.
+    follow: Mitverfolgen ein/aussschalten.
+    help: Anzeigen der Hilfe.
+    refresh: Inhalte neu laden.
+    reload: Showoff vollstämdig neu laden.
+    blank: Bildschirm leeren.
+    footer: Fußzeite eun/ausschalten.
+    notes: Hinweise ein/ausschalten.
+    clear: Ergebnisse löschen.
+    pause: Pausieren der Präsentation.
+    preshow: Anzeigen der Präsentation <tt>preshow</tt> mit einem Timer.
+    execute: Ausführen des ersten sichtbaren Blocks.
+    debug: Anzeigen von Debug Informationen.
+    close: Schließen.
+
+  stats:
+    title: Ansischtsstatistiken.
+    stray: der Teilnehmer sehen eine andere Folie.
+    idle: der Teilnehmer sind inaktiv.
+    current: Aktuelle Folien.
+    elapsed: Zeit pro Folie.
+    nodata: Keine Daten zum Anzeigen vorhanden.
+    allcurrent: Alle Teilnehmer sehen die Folie des Präsentierenden.
+
+  forms:
+    display: Anzeige der Ergebnisse
+    save: Speichern
+
+  presenter:
+    topbar:
+      annotations: Anmerkungen
+      edit: Folie bearbeiten
+      report: Fehler mit Folie melden
+      stats: Ansichtsstatistiken
+      downloads: Downloads
+      display: Anzeigefenster
+      print: Folien drucken
+      settings: Einstellungen
+      newpage: Im neuen Fenster öffnen...
+      tooltip:
+        annotations: Aktivieren des Anmerkungssystems.
+        edit: Bearbeiten der Folie in einem neuen Fenster.
+        report: Einen Fehler der aktuellen Folie melden.
+        stats: Anschauen, welche Folien von den Teilnehmern betrachtet wurden.
+        downloads: Öffnen des Download Bereiches im Menü oder in einem neuen Fenster.
+        display: Aktivieren des Präsentationsfenster; dieses sollte über den Projektor gezeigt werden.
+        print: Folien in einem neuen Fenster drucken.
+        settings: Öffnen der Einstellungen.
+    preview:
+      next: Nächste Folie
+      previous: Vorherige Folie
+    mobile:
+      update: Aktualisierung
+    notes:
+      label:  Showoff Notizen
+      personal: Persönliche Notizen
+    timer:
+      label: "Timer:"
+      start: Start
+      pause: Pause
+      resume: Fortsetzen
+      cancel: Abbrechen
+      unit: Minuten
+    pace:
+      faster: Langsamer!
+      slower: Schneller!
+    questions: Frage von Teilnehmern
+    annotation:
+      tools: Werkzeuge
+      lines: Linien
+      shapes: Formen
+    status:
+      label: "Folien:"
+    settings:
+      label: Einstellungen
+      close: Schließen
+      follower:
+        label: Aktualisierung Schüler Folien
+        tooltip: Benachrichtigung üder Änderung versenden
+        description: Wenn dies aktiviert ist, bekommt der Showoff Server Informaitonen über Aktualisierungen. Deaktivieren, um versehentlicher Aktualiserungen zu verhindern.
+      remote:
+        label: Remote aktivieren
+        tooltip: Aktiviert das Update durch einen weiteren Präsentierer.
+        description: Wenn dies aktiviert ist, dann kann man die Präsentationvon einem anderen Geräterfolgen (üblicherweise ein Mobiles Endegerät).
+      layout:
+        label: Aktualisierung der Schüler
+        default: Default Ansicht
+        thumbs: Anzeigen von Miniaturansichten der nächsten und vorherigen Folie.
+        beside: Anzeigen der nächsten Folie als Großansicht n der Präsentierer Ansicht.
+        floating: Öffnen der nächsten Folie in einem neuen Fenster.
+        confirmation: Die Sicherheitseinstellungen des Browsers machen es erforderlich, dass das Öffnen eines neuen Fensters bestätigt wird.
+        open: Fenster öffnen
+        cancel: Abbrechen
+        reset:
+          label: Löschen der Showoff Einstellungen.
+          tooltip: Zurücksetzen der Showfoff Einstellungen auf die Standardwerte.
+
+  error:
+    file_not_found: Datei nicht gefunden!

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -129,7 +129,7 @@ en:
         tooltip: Enables tracking of other presenters.
         description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
       layout:
-        label: Update Follower
+        label: Layout
         default: Default Layout
         thumbs: Display thumbnail previews of the next and previous slides.
         beside: Display the next slide as a large preview in the main presenter view.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -108,8 +108,8 @@ en:
       cancel: Cancel
       unit: minutes
     pace:
-      faster: Slow Down!
-      slower: Speed Up!
+      faster: Speed Up!
+      slower: Slow Down!
     questions: Audience Questions
     annotation:
       tools: Tools

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -10,7 +10,7 @@ en:
       slower: Slow Down
       faster: Speed Up
     question:
-      label: XAsk a Question
+      label: Ask a Question
       placeholder: Ask a question...
     feedback:
       label: Send Feedback

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,145 @@
+en:
+  name: Showoff Presentation
+  menu:
+    title: Showoff Menu
+    table_of_contents: Table of Contents
+    downloads: Downloads
+    feedback: Sending...
+    pace:
+      label: The presenter should...
+      slower: Slow Down
+      faster: Speed Up
+    question:
+      label: XAsk a Question
+      placeholder: Ask a question...
+    feedback:
+      label: Send Feedback
+      description: This slide is...
+      worst: Terrible
+      best: Awesome
+      why: Why...?
+      send: Send
+    edit: Edit Current Slide
+    clear_annotations: Clear Annotations
+    close: Close
+    help: Press <code>?</code> for help.
+    anonymous: All features are anonymous.
+  navigation:
+    next: Next
+    previous: Previous
+  loading: loading presentation...
+  activity_complete: Activity complete
+  follow:
+    label: "Follow Mode:"
+  refresh: "Are you sure you want to refresh the slide content?\n\n(Use `RELOAD` to fully reload the entire UI)"
+  reload: Are you sure you want to reload Showoff?
+  preshow:
+    prompt: Minutes from now to start?
+    resume: "Resuming in:"
+
+  downloads:
+    title: File Downloads
+
+  help:
+    title: Help
+    next: Move to the next slide.
+    prev: Move to the previous slide.
+    contents: Show the table of contents menu.
+    follow: Toggle follow mode.
+    help: Show this help dialog.
+    refresh: Refresh slide content.
+    reload: Completely reload Showoff.
+    blank: Blank the screen.
+    footer: Toggle the display footer.
+    notes: Toggle notes display.
+    clear: Clear code execution results.
+    pause: Pause the presentation.
+    preshow: Display slideshow of <tt>preshow</tt> images on a timer.
+    execute: Execute the first visible code block.
+    debug: Show debugging information.
+    close: Close
+
+  stats:
+    title: Viewing Statistics
+    stray: of your audience is not viewing the same slide you are.
+    idle: of your audience is idle.
+    current: Slides currently being viewed
+    elapsed: Elapsed time spent on each slide
+    nodata: No data to display.
+    allcurrent: All audience members are viewing the presenter's slide.
+
+  forms:
+    display: Display Results
+    save: Save
+
+  presenter:
+    topbar:
+      annotations: Annotations
+      edit: Edit Slide
+      report: Report Issue With Slide
+      stats: Viewing Statistics
+      downloads: Downloads
+      display: Display Window
+      print: Print Slides
+      settings: Settings
+      newpage: Open in a new page...
+      tooltip:
+        annotations: Enable the annotations subsystem.
+        edit: Edit current slide in new window.
+        report: Report an issue with the current slide.
+        stats: See the slides your audience is interacting with.
+        downloads: Open the file downloads in a menu or new page.
+        display: Enable the Display Window; you should put this on the projector.
+        print: Print slides using a new window.
+        settings: Open the Settings dialog.
+    preview:
+      next: Next
+      previous: Previous
+    mobile:
+      update: Update
+    notes:
+      label:  Showoff Notes
+      personal: Personal Notes
+    timer:
+      label: "Timer:"
+      start: Start
+      pause: Pause
+      resume: Resume
+      cancel: Cancel
+      unit: minutes
+    pace:
+      faster: Slow Down!
+      slower: Speed Up!
+    questions: Audience Questions
+    annotation:
+      tools: Tools
+      lines: Lines
+      shapes: Shapes
+    status:
+      label: "Slides:"
+    settings:
+      label: Settings
+      close: Close
+      follower:
+        label: Update Follower
+        tooltip: Send slide change notifications.
+        description: When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+      remote:
+        label: Enable Remote
+        tooltip: Enables tracking of other presenters.
+        description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+      layout:
+        label: Update Follower
+        default: Default Layout
+        thumbs: Display thumbnail previews of the next and previous slides.
+        beside: Display the next slide as a large preview in the main presenter view.
+        floating: Open the next slide as a floating window.
+        confirmation: Browser security requires confirmation before opening a new window.
+        open: Open Window
+        cancel: cancel
+        reset:
+          label: Clear Showoff settings.
+          tooltip: Reset Showoff UI settings to default values.
+
+  error:
+    file_not_found: File Not Found!

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   name: Presentación en Showoff
   menu:
     title: Menú de Showoff

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -1,0 +1,145 @@
+en:
+  name: Presentación en Showoff
+  menu:
+    title: Menú de Showoff
+    table_of_contents: Tabla de Contenidos
+    downloads: Descargas
+    feedback: Enviando...
+    pace:
+      label: El Presentador Debería...
+      slower: Ir Más Despacio
+      faster: Ir Más Rápido
+    question:
+      label: Hacer una Pregunta
+      placeholder: Hacer una pregunta...
+    feedback:
+      label: Enviar Sugerencias
+      description: Esta Diapositiva es...
+      worst: Terrible
+      best: Genial
+      why: Por Qué...?
+      send: Enviar
+    edit: Editar Esta Diapositiva
+    clear_annotations: Limpiar Notas
+    close: Cerrar
+    help: Presionar <code>?</code> para ver ayuda.
+    anonymous: Todas las funciones son anónimas.
+  navigation:
+    next: Siguiente
+    previous: Anterior
+  loading: cargando presentación...
+  activity_complete: Actividad completa
+  follow:
+    label: "Modo de Seguimiento:"
+  refresh: "Está seguro que desea refrescar el contenido de la diapositiva?\n\n(Use `RELOAD` para refrescar la interfaz entera)"
+  reload: Está seguro que desea refrescar Showoff?
+  preshow:
+    prompt: Minutos desde ahora al comienzo?
+    resume: "Continuando en:"
+
+  downloads:
+    title: Descarga de Archivos
+
+  help:
+    title: Ayuda
+    next: Mover a la siguiente diapositiva.
+    prev: Mover a la diapositiva anterior.
+    contents: Mostrar el menú de la tabla de contenidos.
+    follow: Habilitar el modo de seguimiento.
+    help: Mostrar éste dialogo de ayuda.
+    refresh: Refrescar el contenido de la diapositiva.
+    reload: Refrescar el contenido total de Showoff.
+    blank: Oscurecer la pantalla.
+    footer: Habilitar/Deshabilitar las notas de pie de página.
+    notes: Habilitar/Deshabilitar notas de Showoff.
+    clear: Limpiar los resultados de la ejecución de código.
+    pause: Pausar la presentación.
+    preshow: Mostrar las diapositivas de imágenes de <tt>preshow</tt> con un contador de tiempo.
+    execute: Ejecutar el primer bloque de código visible.
+    debug: Mostrar información de debug.
+    close: Cerrar
+
+  stats:
+    title: Ver Estadísticas
+    stray: tu audiencia no está viendo la misma diapositiva que tú.
+    idle: tu audiencia no está activa.
+    current: Diapositivas que están siendo vistas
+    elapsed: Tiempo transcurrido en cada diapositiva
+    nodata: No hay información para mostrar.
+    allcurrent: Todos los miembros de la audiencia están viendo la diapositiva del presentador.
+
+  forms:
+    display: Mostrar Resultados
+    save: Guardar
+
+  presenter:
+    topbar:
+      annotations: Notas
+      edit: Editar Diapositiva
+      report: Reportar Problema con Diapositiva
+      stats: Ver Estadísticas
+      downloads: Descargas
+      display: Ventana de Presentación
+      print: Imprimir Diapositivas
+      settings: Configuraciones
+      newpage: Abrir en una nueva página...
+      tooltip:
+        annotations: Habilitar el subsistema de notas.
+        edit: Editar diapositiva actual en nueva ventana.
+        report: Reportar un problema con diapositiva actual.
+        stats: Ver las diapositivas que tu audiencia está viendo.
+        downloads: Abrir descargas en un menú o en una nueva página.
+        display: Habilitar la ventana de presentación; esta ventana debería ser mostrada en el proyector.
+        print: Imprimir diapositivas usando una nueva ventana.
+        settings: Abrir menú de Configuraciones.
+    preview:
+      next: Siguiente
+      previous: Anterior
+    mobile:
+      update: Actualizar
+    notes:
+      label:  Notas de Showoff
+      personal: Notas Personales
+    timer:
+      label: "Contador de Tiempo:"
+      start: Iniciar
+      pause: Pausar
+      resume: Continuar
+      cancel: Cancelar
+      unit: minutos
+    pace:
+      faster: Ir Más Rápido!
+      slower: Ir Más Despacio!
+    questions: Preguntas de la Audiencia
+    annotation:
+      tools: Herramientas
+      lines: Líneas
+      shapes: Figuras
+    status:
+      label: "Diapositivas:"
+    settings:
+      label: Configuraciones
+      close: Cerrar
+      follower:
+        label: Actualizar Seguidor
+        tooltip: Enviar diapositiva de cambio de notificaciones
+        description: Cuando esta opción está habilitada, el servidor de Showoff rastreará los cambios de tu diapositiva. Deshabilítalo para ver la presentación sin causar cambios inesperados.
+      remote:
+        label: Habilitar Remoto
+        tooltip: Habilita el rastreo de otros presentadores.
+        description: Cuando esta opción está habilitada, puedes cargar la presentación en otro navegador (usualmente tu teléfono celular) para controlar la presentación.
+      layout:
+        label: Actualizar Seguidor
+        default: Diseño Estándar
+        thumbs: Mostrar miniatura de las diapositivas siguiente y anterior.
+        beside: Mostrar la siguiente diapositiva en la vista principal del presentador.
+        floating: Abrir la siguiente diapositiva en una ventana flotante.
+        confirmation: La seguridad del navegador require confirmación para abrir una ventana nueva.
+        open: Abrir Ventana
+        cancel: cancelar
+        reset:
+          label: Limpiar configuraciones de Showoff.
+          tooltip: Cambia las configuraciones de Showoff a sus valores iniciales.
+
+  error:
+    file_not_found: Archivo No Encontrado!

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1,0 +1,145 @@
+fr:
+  name: Showoff Présentation
+  menu:
+    title: Showoff Menu
+    table_of_contents: Table des Matières
+    downloads: Téléchargements
+    feedback: Envoi...
+    pace:
+      label: Le présentateur devrait...
+      slower: Ralentir
+      faster: Accélérer
+    question:
+      label: Poser Une Question
+      placeholder: Poser une question...
+    feedback:
+      label: Envoyer des Commentaires
+      description: Cette diapositive est...
+      worst: Mauvais
+      best: Fantastique
+      why: Pourquoi...?
+      send: Envoi
+    edit: Modifier la Diapositive Actuelle
+    clear_annotations: Effacer les Annotations
+    close: Fermer
+    help: Presse <code>?</code> pour aider.
+    anonymous: Toutes les fonctionnalités sont anonymes.
+  navigation:
+    next: Prochain
+    previous: Précédent
+  loading: Chargement de la présentation...
+  activity_complete: Activité terminée
+  follow:
+    label: "Suivre le Mode:"
+  refresh: "Voulez-vous vraiment actualiser le contenu de la diapositive?\n\n(Utilisez «RELOAD» pour recharger complètement l'interface utilisateur complète)"
+  reload: Voulez-vous vraiment recharger Showoff?
+  preshow:
+    prompt: Minutes à partir de maintenant pour commencer?
+    resume: "Reprise dans:"
+
+  downloads:
+    title: Téléchargements de fichiers
+
+  help:
+    title: Aider
+    next: Passer à la diapositive suivante.
+    prev: Passer à la diapositive précédente.
+    contents: Afficher le menu de la table des matières.
+    follow: Activer le mode de suivi.
+    help: Afficher cette fenêtre d'aide.
+    refresh: Actualiser le contenu des diapositives.
+    reload: Complètement recharger Showoff.
+    blank: Videz l'écran.
+    footer: Basculer le pied de page d'affichage.
+    notes: Affichage des notes à bascule.
+    clear: Effacer les résultats d'exécution de code.
+    pause: Mettre en pause la présentation.
+    preshow: Afficher le diaporama des images <tt>présélection</tt> sur une minuterie.
+    execute: Exécuter le premier bloc de code visible.
+    debug: Afficher les informations de débogage.
+    close: Fermer
+
+  stats:
+    title: Affichage des statistiques
+    stray: de votre public ne regarde pas la même diapositive que vous êtes.
+    idle: de votre auditoire est inactif.
+    current: Diapositives en cours d'affichage
+    elapsed: Temps écoulé passé sur chaque lame
+    nodata: Aucune donnée à afficher.
+    allcurrent: Tous les membres du public regardent la diapositive du présentateur.
+
+  forms:
+    display: Afficher les résultats
+    save: Conserver
+
+  presenter:
+    topbar:
+      annotations: Annotations
+      edit: Modifier la Diapositive
+      report: Signaler un Problème avec la Diapositive
+      stats: Affichage des Statistiques
+      downloads: Téléchargements
+      display: Fenêtre d'Affichage
+      print: Imprimer Diapositives
+      settings: Paramètres
+      newpage: Ouvrir dans une nouvelle page...
+      tooltip:
+        annotations: Activer le sous-système annotations.
+        edit: Modifier la diapositive actuelle dans une nouvelle fenêtre.
+        report: Signaler un problème avec la diapositive actuelle.
+        stats: Voir les diapositives avec lesquelles votre public interagit.
+        downloads: Ouvrez les téléchargements de fichiers dans un menu ou une nouvelle page.
+        display: Activer la fenêtre d'affichage; Vous devriez le mettre sur le projecteur.
+        print: Imprimer des diapositives à l'aide d'une nouvelle fenêtre.
+        settings: Ouvrez la boîte de dialogue Paramètres.
+    preview:
+      next: Prochain
+      previous: Précédent
+    mobile:
+      update: Réviser
+    notes:
+      label:  Showoff Remarques
+      personal: Remarques Personnelles
+    timer:
+      label: "Minuteur:"
+      start: Commencer
+      pause: Pause
+      resume: Reprendre
+      cancel: Annuler
+      unit: minutes
+    pace:
+      faster: Accélérer!
+      slower: Ralentissez!
+    questions: Questions d'Audience
+    annotation:
+      tools: Outils
+      lines: Lignes
+      shapes: Formes
+    status:
+      label: "Diapositives:"
+    settings:
+      label: Paramètres
+      close: Fermer
+      follower:
+        label: Mise à Jour
+        tooltip: Envoyer des notifications de modification de diapositive.
+        description: Lorsque cette option est activée, le serveur Showoff effectuera le suivi des modifications apportées aux diapositives. Désactivez-le pour observer la présentation sans provoquer par inadvertance des changements de diapositives.
+      remote:
+        label: Activer la télécommande
+        tooltip: Permet le suivi d'autres présentateurs.
+        description: Lorsque cette option est activée, vous pouvez charger le présentateur dans un autre navigateur (généralement sur votre téléphone portable) pour contrôler la présentation.
+      layout:
+        label: Disposition
+        default: Configuration par défaut.
+        thumbs: Afficher les aperçus des vignettes des diapositives suivantes et précédentes.
+        beside: Affichez la diapositive suivante comme un aperçu général dans la vue du présentateur principal.
+        floating: Ouvrez la diapositive suivante comme une fenêtre flottante.
+        confirmation: La sécurité du navigateur requiert confirmation avant d'ouvrir une nouvelle fenêtre.
+        open: Fenêtre ouverte
+        cancel: Annuler
+        reset:
+          label: Réinitialiser les paramètres.
+          tooltip: Réinitialiser les paramètres de l'interface utilisateur Showoff aux valeurs par défaut.
+
+  error:
+    file_not_found: Fichier non trouvé!

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -27,74 +27,81 @@ ja:
   navigation:
     next: 次へ
     previous: 前へ
-  loading: プレゼンテーションをロード中...
+  loading: プレゼンテーション？ロード中...
   activity_complete: アクティビティ完了
   follow:
-    label: "フォローモード:"
-  refresh: "Are you sure you want to refresh the slide content?\n\n(Use `RELOAD` to fully reload the entire UI)"
+    label: "フォロー・モード:"
+    # The below line assumes the RELOAD button is graphic instead of text, otherwise replace with リロード
+  refresh: "スライドの内容を更新してもよろしいですか？\n\n(UI全体を全部にリロードするには `RELOAD`を使います)"
   reload: Showoffをリロードしてもよろしいですか？
   preshow:
     prompt: 今から何分かかりますか？
     resume: "再開:"
 
   downloads:
-    title: File Downloads
-
+    title: ファイルダウンロード
+    
   help:
-    title: Help
-    next: Move to the next slide.
-    prev: Move to the previous slide.
-    contents: Show the table of contents menu.
-    follow: Toggle follow mode.
-    help: Show this help dialog.
-    refresh: Refresh slide content.
-    reload: Completely reload Showoff.
-    blank: Blank the screen.
-    footer: Toggle the display footer.
-    notes: Toggle notes display.
-    clear: Clear code execution results.
-    pause: Pause the presentation.
-    preshow: Display slideshow of <tt>preshow</tt> images on a timer.
-    execute: Execute the first visible code block.
-    debug: Show debugging information.
-    close: Close
+    title: ヘルプ
+    next: 次のスライドに移動します。
+    prev: 前のスライドに移動します。
+    contents: 目次メニュを表示する。
+    follow: フォローモードを切り替えます。
+    help: このヘルプダイアログを表示します。
+    refresh: スライドの内容を更新します。
+    reload: Showoffを全てにリロードする。
+    blank: 画面を空白にする。
+    footer: 表示フッターを切り替えます。
+    notes: ノートを切り替えます。
+    clear: コード実行結果をクリアします。
+    pause: プレゼンテーションを一時停止する。
+    #Not familiar with a functioning word for "preshow" so went with "preview"
+    preshow: <tt>プレビュー</ tt>画像のスライドショーをタイマーに表示します。
+    execute: 最初に表示されるコードブロックを実行します。
+    debug: デバッグ情報を表示します。
+    close: 閉じる
 
   stats:
-    title: Viewing Statistics
-    stray: of your audience is not viewing the same slide you are.
-    idle: of your audience is idle.
-    current: Slides currently being viewed
-    elapsed: Elapsed time spent on each slide
-    nodata: No data to display.
-    allcurrent: All audience members are viewing the presenter's slide.
+  #Shifted meaning to "Participant Statistics" since I couldn't identify a satisfactory parallel word with Viewing in context.
+    title: 参加者の統計
+    #It's not gramatically correct to have the number of viewers first in Japanese (Subject, Object, Verb Order), so
+    #Represented the number with ### to not break any typification in the existing parsing of bracket contents.
+    #stray alternate: 聴衆のメンバーはあなたのスライドを見ていない  # This allows the number to be at first, but may sound stilted.
+    stray: あなたの聴衆のうち###人があなたと同じスライドを見ていません。
+    #idle alternate: 聴衆のメンバーは現在を無為んでいます
+    idle: あなたの聴衆のうち###人が無為んでいます。
+    current: 現在見ているスライド
+    elapsed: 各スライドに費やされた経過時間
+    nodata: 表示するデータがありません。
+    allcurrent: すべての聴衆メンバーがプレゼンターのスライドを見ています。
 
   forms:
-    display: Display Results
-    save: Save
-
+    display: 結果を表示
+    save: セーブ
+    
   presenter:
     topbar:
-      annotations: Annotations
-      edit: Edit Slide
-      report: Report Issue With Slide
-      stats: Viewing Statistics
-      downloads: Downloads
-      display: Display Window
-      print: Print Slides
-      settings: Settings
-      newpage: Open in a new page...
+      annotations: 注釈
+      edit: スライドを編集する
+      report: スライドによる問題の報告
+      stats: 参加者の統計
+      downloads: ダウンロード
+      display: 表示ウィンドウ
+      print: スライドを印刷する
+      settings: 設定
+      newpage: 新しいページで開く...
       tooltip:
-        annotations: Enable the annotations subsystem.
-        edit: Edit current slide in new window.
-        report: Report an issue with the current slide.
+        annotations: 注釈サブシステムを有効にします。
+        edit: 現在のスライドを新しいウィンドウで編集します。
+        report: 現在のスライドで問題を報告します。
         stats: See the slides your audience is interacting with.
         downloads: Open the file downloads in a menu or new page.
         display: Enable the Display Window; you should put this on the projector.
         print: Print slides using a new window.
         settings: Open the Settings dialog.
     preview:
-      next: Next
-      previous: Previous
+      next: 次へ
+      previous: 前へ
     mobile:
       update: Update
     notes:
@@ -102,11 +109,11 @@ ja:
       personal: Personal Notes
     timer:
       label: "Timer:"
-      start: Start
-      pause: Pause
-      resume: Resume
-      cancel: Cancel
-      unit: minutes
+      start: 始める
+      pause: 一時停止
+      resume: 続ける
+      cancel: キャンセル
+      unit: 分
     pace:
       faster: Speed Up!
       slower: Slow Down!
@@ -119,7 +126,7 @@ ja:
       label: "Slides:"
     settings:
       label: Settings
-      close: Close
+      close: 閉じる
       follower:
         label: Update Follower
         tooltip: Send slide change notifications.

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -94,9 +94,9 @@ ja:
         annotations: 注釈サブシステムを有効にします。
         edit: 現在のスライドを新しいウィンドウで編集します。
         report: 現在のスライドで問題を報告します。
-        stats: See the slides your audience is interacting with.
-        downloads: Open the file downloads in a menu or new page.
-        display: Enable the Display Window; you should put this on the projector.
+        stats: 聴衆がインタラクションしているスライドを見る。
+        downloads: メニューまたは新しいページでファイルのダウンロードを開く。
+        display: 表示ウィンドウをエネーブルにする。 これをプロジェクターに置いてください。
         print: Print slides using a new window.
         settings: Open the Settings dialog.
     preview:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -19,23 +19,23 @@ ja:
       best: さいこ
       why: どうして。。。？
       send: 送信
-    edit: Edit Current Slide
-    clear_annotations: Clear Annotations
-    close: Close
-    help: Press <code>?</code> for help.
-    anonymous: All features are anonymous.
+    edit: このスライドを編集する
+    clear_annotations: 注釈をクリアする
+    close: 閉じる
+    help: <code>?</code>キーを押してヘルプを表示します。
+    anonymous: すべての機能は識別されません
   navigation:
-    next: Next
-    previous: Previous
-  loading: loading presentation...
-  activity_complete: Activity complete
+    next: 次へ
+    previous: 前へ
+  loading: プレゼンテーションをロード中...
+  activity_complete: アクティビティ完了
   follow:
-    label: "Follow Mode:"
+    label: "フォローモード:"
   refresh: "Are you sure you want to refresh the slide content?\n\n(Use `RELOAD` to fully reload the entire UI)"
-  reload: Are you sure you want to reload Showoff?
+  reload: Showoffをリロードしてもよろしいですか？
   preshow:
-    prompt: Minutes from now to start?
-    resume: "Resuming in:"
+    prompt: 今から何分かかりますか？
+    resume: "再開:"
 
   downloads:
     title: File Downloads

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -129,7 +129,7 @@ ja:
         tooltip: Enables tracking of other presenters.
         description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
       layout:
-        label: Update Follower
+        label: Layout
         default: Default Layout
         thumbs: Display thumbnail previews of the next and previous slides.
         beside: Display the next slide as a large preview in the main presenter view.

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -1,4 +1,4 @@
-jp:
+ja:
   name: Showoff プレゼンテーション
   menu:
     title: Showoff メニュー

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -40,7 +40,7 @@ ja:
 
   downloads:
     title: ファイルダウンロード
-    
+
   help:
     title: ヘルプ
     next: 次のスライドに移動します。
@@ -56,7 +56,7 @@ ja:
     clear: コード実行結果をクリアします。
     pause: プレゼンテーションを一時停止する。
     #Not familiar with a functioning word for "preshow" so went with "preview"
-    preshow: <tt>プレビュー</ tt>画像のスライドショーをタイマーに表示します。
+    preshow: <tt>プレビュー</tt>画像のスライドショーをタイマーに表示します。
     execute: 最初に表示されるコードブロックを実行します。
     debug: デバッグ情報を表示します。
     close: 閉じる
@@ -78,7 +78,7 @@ ja:
   forms:
     display: 結果を表示
     save: セーブ
-    
+
   presenter:
     topbar:
       annotations: 注釈

--- a/locales/jp.yml
+++ b/locales/jp.yml
@@ -1,0 +1,145 @@
+jp:
+  name: Showoff プレゼンテーション
+  menu:
+    title: Showoff メニュー
+    table_of_contents: 目次
+    downloads: ダウンロード
+    feedback: 送信する。。。
+    pace:
+      label: 発表者は。。。
+      slower: もっと遅くしてください
+      faster: もっと早くしてください
+    question:
+      label: 質問を問いかける
+      placeholder: 質問を問いかける。。。
+    feedback:
+      label: フィードバックに送信する
+      description: このスライドは。。。
+      worst: さいてい
+      best: さいこ
+      why: どうして。。。？
+      send: 送信
+    edit: Edit Current Slide
+    clear_annotations: Clear Annotations
+    close: Close
+    help: Press <code>?</code> for help.
+    anonymous: All features are anonymous.
+  navigation:
+    next: Next
+    previous: Previous
+  loading: loading presentation...
+  activity_complete: Activity complete
+  follow:
+    label: "Follow Mode:"
+  refresh: "Are you sure you want to refresh the slide content?\n\n(Use `RELOAD` to fully reload the entire UI)"
+  reload: Are you sure you want to reload Showoff?
+  preshow:
+    prompt: Minutes from now to start?
+    resume: "Resuming in:"
+
+  downloads:
+    title: File Downloads
+
+  help:
+    title: Help
+    next: Move to the next slide.
+    prev: Move to the previous slide.
+    contents: Show the table of contents menu.
+    follow: Toggle follow mode.
+    help: Show this help dialog.
+    refresh: Refresh slide content.
+    reload: Completely reload Showoff.
+    blank: Blank the screen.
+    footer: Toggle the display footer.
+    notes: Toggle notes display.
+    clear: Clear code execution results.
+    pause: Pause the presentation.
+    preshow: Display slideshow of <tt>preshow</tt> images on a timer.
+    execute: Execute the first visible code block.
+    debug: Show debugging information.
+    close: Close
+
+  stats:
+    title: Viewing Statistics
+    stray: of your audience is not viewing the same slide you are.
+    idle: of your audience is idle.
+    current: Slides currently being viewed
+    elapsed: Elapsed time spent on each slide
+    nodata: No data to display.
+    allcurrent: All audience members are viewing the presenter's slide.
+
+  forms:
+    display: Display Results
+    save: Save
+
+  presenter:
+    topbar:
+      annotations: Annotations
+      edit: Edit Slide
+      report: Report Issue With Slide
+      stats: Viewing Statistics
+      downloads: Downloads
+      display: Display Window
+      print: Print Slides
+      settings: Settings
+      newpage: Open in a new page...
+      tooltip:
+        annotations: Enable the annotations subsystem.
+        edit: Edit current slide in new window.
+        report: Report an issue with the current slide.
+        stats: See the slides your audience is interacting with.
+        downloads: Open the file downloads in a menu or new page.
+        display: Enable the Display Window; you should put this on the projector.
+        print: Print slides using a new window.
+        settings: Open the Settings dialog.
+    preview:
+      next: Next
+      previous: Previous
+    mobile:
+      update: Update
+    notes:
+      label:  Showoff Notes
+      personal: Personal Notes
+    timer:
+      label: "Timer:"
+      start: Start
+      pause: Pause
+      resume: Resume
+      cancel: Cancel
+      unit: minutes
+    pace:
+      faster: Speed Up!
+      slower: Slow Down!
+    questions: Audience Questions
+    annotation:
+      tools: Tools
+      lines: Lines
+      shapes: Shapes
+    status:
+      label: "Slides:"
+    settings:
+      label: Settings
+      close: Close
+      follower:
+        label: Update Follower
+        tooltip: Send slide change notifications.
+        description: When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+      remote:
+        label: Enable Remote
+        tooltip: Enables tracking of other presenters.
+        description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+      layout:
+        label: Update Follower
+        default: Default Layout
+        thumbs: Display thumbnail previews of the next and previous slides.
+        beside: Display the next slide as a large preview in the main presenter view.
+        floating: Open the next slide as a floating window.
+        confirmation: Browser security requires confirmation before opening a new window.
+        open: Open Window
+        cancel: cancel
+        reset:
+          label: Clear Showoff settings.
+          tooltip: Reset Showoff UI settings to default values.
+
+  error:
+    file_not_found: File Not Found!

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -129,7 +129,7 @@ nl:
         tooltip: Hiermee kun je de slides wisselen vanaf andere presenters.
         description: Wanneer dit is ingeschakeld, kun je de presentatie besturen vanaf een andere browser (Bijvoorbeeld je mobiele telefoon).
       layout:
-        label: Update Volgers
+        label: Layout
         default: Standaard layout
         thumbs: Toon previews van de volgende en vorige slides.
         beside: Toon de volgende slide als grote preview.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -1,4 +1,4 @@
-en:
+nl:
   name: Showoff Presentatie
   menu:
     title: Showoff Menu

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -87,59 +87,59 @@ en:
         annotations: Schakel aantekeningen in.
         edit: Bewerk huidige slide in nieuw scherm.
         report: Meld een probleem met de huidige slide.
-        stats: See the slides your audience is interacting with.
-        downloads: Open the file downloads in a menu or new page.
-        display: Enable the Display Window; you should put this on the projector.
-        print: Print slides using a new window.
-        settings: Open the Settings dialog.
+        stats: Bekijk met welke slides je publiek bezig zijn.
+        downloads: Open de Downloads in een menu of nieuwe pagina.
+        display: Open het Presentatiescherm, deze kun je op de projector zetten.
+        print: Print je slides in een nieuw scherm.
+        settings: Open het Instellingen scherm.
     preview:
-      next: Next
-      previous: Previous
+      next: Volgende
+      previous: Vorige
     mobile:
       update: Update
     notes:
-      label:  Showoff Notes
-      personal: Personal Notes
+      label:  Showoff Notities
+      personal: Persoonlijke Notities
     timer:
       label: "Timer:"
       start: Start
       pause: Pause
-      resume: Resume
-      cancel: Cancel
-      unit: minutes
+      resume: Hervatten
+      cancel: Annuleren
+      unit: minuten
     pace:
-      faster: Speed Up!
-      slower: Slow Down!
-    questions: Audience Questions
+      faster: Sneller!
+      slower: Langzamer!
+    questions: Vragen van het publiek
     annotation:
       tools: Tools
-      lines: Lines
-      shapes: Shapes
+      lines: Lijnen
+      shapes: Vormen
     status:
       label: "Slides:"
     settings:
-      label: Settings
-      close: Close
+      label: Instellingen
+      close: Sluiten
       follower:
-        label: Update Follower
-        tooltip: Send slide change notifications.
-        description: When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+        label: Update Volger
+        tooltip: Stuur slide wisselingen naar volgers.
+        description: Wanneer dit is ingeschakeld, geeft de Showoff server de slide wisselingen door. Schakel dit uit om door de slides te bladeren zonder ze te wisselen bij je publiek.
       remote:
-        label: Enable Remote
-        tooltip: Enables tracking of other presenters.
-        description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+        label: Schakel remote in
+        tooltip: Hiermee kun je de slides wisselen vanaf andere presenters.
+        description: Wanneer dit is ingeschakeld, kun je de presentatie besturen vanaf een andere browser (Bijvoorbeeld je mobiele telefoon).
       layout:
-        label: Update Follower
-        default: Default Layout
-        thumbs: Display thumbnail previews of the next and previous slides.
-        beside: Display the next slide as a large preview in the main presenter view.
-        floating: Open the next slide as a floating window.
-        confirmation: Browser security requires confirmation before opening a new window.
-        open: Open Window
-        cancel: cancel
+        label: Update Volgers
+        default: Standaard layout
+        thumbs: Toon previews van de volgende en vorige slides.
+        beside: Toon de volgende slide als grote preview.
+        floating: Open de volgende slide in een apart scherm.
+        confirmation: De beveiligingsinstellingen van de browser vereist een bevestiging om een nieuw scherm te openen.
+        open: Open Scherm
+        cancel: annuleren
         reset:
-          label: Clear Showoff settings.
-          tooltip: Reset Showoff UI settings to default values.
+          label: Reset Showoff instellingen.
+          tooltip: Reset Showoff UI instellingen naar standaard.
 
   error:
-    file_not_found: File Not Found!
+    file_not_found: Bestand niet gevonden!

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -1,0 +1,145 @@
+en:
+  name: Showoff Presentatie
+  menu:
+    title: Showoff Menu
+    table_of_contents: Inhoudsopgave
+    downloads: Downloads
+    feedback: Verzenden...
+    pace:
+      label: De spreker gaat...
+      slower: Te snel
+      faster: Te langzaam
+    question:
+      label: Stel een vraag
+      placeholder: Stel een vraag...
+    feedback:
+      label: Stuur Feedback
+      description: Deze slide is...
+      worst: Vreselijk
+      best: Geweldig
+      why: Waarom...?
+      send: Verstuur
+    edit: Bewerk huidige slide
+    clear_annotations: Wis aantekeningen
+    close: Sluiten
+    help: Druk op <code>?</code> voor help.
+    anonymous: Alle opties zijn anoniem.
+  navigation:
+    next: Volgende
+    previous: Vorige
+  loading: Laden van presentatie...
+  activity_complete: Activiteiten voltooid
+  follow:
+    label: "Volgmodus:"
+  refresh: "Weet je zeker dat je de presentatie wilt vernieuwen?\n\n(Gebruik `RELOAD` om de hele UI te vernieuwen)"
+  reload: Weet je zeker dat je Showoff wilt herstarten?
+  preshow:
+    prompt: Hoeveel minuten tot het begin?
+    resume: "Start over:"
+
+  downloads:
+    title: Downloads
+
+  help:
+    title: Help
+    next: Ga naar de volgende slide.
+    prev: Ga naar de vorige slide.
+    contents: Toon de inhoudsopgave.
+    follow: Schakel volgmodus in.
+    help: Toon dit scherm.
+    refresh: Ververs de presentatie.
+    reload: Herstart Showoff.
+    blank: Maak het scherm zwart.
+    footer: Schakel de footer in of uit.
+    notes: Schakel de notities in of uit.
+    clear: Wis het resultaat van code executie.
+    pause: Pauzeer de presentatie.
+    preshow: Toon de slideshow van <tt>preshow</tt> afbeeldingen.
+    execute: Vooer het eerst zichtbare code block uit.
+    debug: Toon debugging info.
+    close: Sluiten
+
+  stats:
+    title: Statistieken
+    stray: van je publiek zit niet op dezelfde slide als jij.
+    idle: van je publiek doet niet mee.
+    current: Slides die worden getoont
+    elapsed: Tijd doorgebracht op slides
+    nodata: Geen data om te tonen.
+    allcurrent: Alle deelnemers zitten op dezelfde slide als jij.
+
+  forms:
+    display: Toon resultaten
+    save: Opslaan
+
+  presenter:
+    topbar:
+      annotations: Aantekeningen
+      edit: Bewerk Slide
+      report: Rapporteer probleem met Slide
+      stats: Bekijk Statistieken
+      downloads: Downloads
+      display: Presentatiescherm
+      print: Print Slides
+      settings: Instellingen
+      newpage: Open op een nieuwe pagina...
+      tooltip:
+        annotations: Schakel aantekeningen in.
+        edit: Bewerk huidige slide in nieuw scherm.
+        report: Meld een probleem met de huidige slide.
+        stats: See the slides your audience is interacting with.
+        downloads: Open the file downloads in a menu or new page.
+        display: Enable the Display Window; you should put this on the projector.
+        print: Print slides using a new window.
+        settings: Open the Settings dialog.
+    preview:
+      next: Next
+      previous: Previous
+    mobile:
+      update: Update
+    notes:
+      label:  Showoff Notes
+      personal: Personal Notes
+    timer:
+      label: "Timer:"
+      start: Start
+      pause: Pause
+      resume: Resume
+      cancel: Cancel
+      unit: minutes
+    pace:
+      faster: Speed Up!
+      slower: Slow Down!
+    questions: Audience Questions
+    annotation:
+      tools: Tools
+      lines: Lines
+      shapes: Shapes
+    status:
+      label: "Slides:"
+    settings:
+      label: Settings
+      close: Close
+      follower:
+        label: Update Follower
+        tooltip: Send slide change notifications.
+        description: When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+      remote:
+        label: Enable Remote
+        tooltip: Enables tracking of other presenters.
+        description: When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+      layout:
+        label: Update Follower
+        default: Default Layout
+        thumbs: Display thumbnail previews of the next and previous slides.
+        beside: Display the next slide as a large preview in the main presenter view.
+        floating: Open the next slide as a floating window.
+        confirmation: Browser security requires confirmation before opening a new window.
+        open: Open Window
+        cancel: cancel
+        reset:
+          label: Clear Showoff settings.
+          tooltip: Reset Showoff UI settings to default values.
+
+  error:
+    file_not_found: File Not Found!

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -176,6 +176,9 @@
       margin: 2px 0px;
     }
 
+    #timerSection #startTimer {
+      float: right;
+    }
     #timerSection #pauseTimer {
       float: left;
       display: none;

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -51,6 +51,11 @@ $(document).ready(function(){
 
   chooseLayout(null);
 
+  // must be defined using [] syntax for a variable button name on IE.
+  var closeLabel      = I18n.t('presenter.settings.close');
+  var buttons         = {};
+  buttons[closeLabel] = function() { $(this).dialog( "close" ); };
+
   $("#settings-modal").dialog({
     autoOpen: false,
     dialogClass: "no-close",
@@ -59,11 +64,7 @@ $(document).ready(function(){
     modal: true,
     resizable: false,
     width: 400,
-    buttons: {
-      Close: function() {
-        $( this ).dialog( "close" );
-      }
-    }
+    buttons: buttons
   });
 
   $("#annotationsToggle").checkboxradio({
@@ -156,7 +157,7 @@ $(document).ready(function(){
       var percent = json['stray_p'];
       if(percent > 25) {
         $('#topbar #statslink').addClass('warning');
-        $('#topbar #statslink').attr('title', percent + "% of your audience is not viewing the same slide you are.");
+        $('#topbar #statslink').attr('title', percent + '%' +  I18n.t('stats.stray'));
       }
       else {
         $('#stray').hide(); // in case the popup is open
@@ -213,7 +214,7 @@ function presenterPopupToggle(page, event) {
         href: page,
         target: '_new'
       });
-      link.text('Open in a new page...');
+      link.text(I18n.t('presenter.topbar.newpage'));
 
       content.attr('id', page.substring(1, page.length));
       content.append(link);
@@ -354,7 +355,7 @@ function toggleNotes() {
   if (mode.notes) {
     try {
       if(windowIsClosed(notesWindow)){
-        notesWindow = blankStyledWindow("Showoff Notes", 'width=350,height=450', 'notes', true);
+        notesWindow = blankStyledWindow(I18n.t('notes.label'), 'width=350,height=450', 'notes', true);
         window.setTimeout(function() {
           // call back and update the parent presenter if the window is closed
           notesWindow.onunload = function(e) {

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -26,6 +26,10 @@ var loadSlidesPrefix
 
 var mode = { track: true, follow: true };
 
+// a dummy websocket object to make standalone presentations easier.
+var ws = {}
+ws.send = function() { /* no-op */ }
+
 // since javascript doesn't have a built-in way to get to cookies easily,
 // let's just add our own data structure.
 document.cookieHash = {}
@@ -974,10 +978,6 @@ function connectControlChannel() {
     ws.onopen    = function()  { connected();          };
     ws.onclose   = function()  { disconnected();       }
     ws.onmessage = function(m) { parseMessage(m.data); };
-  }
-  else {
-    ws = {}
-    ws.send = function() { /* no-op */ }
   }
 }
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -51,6 +51,7 @@ function setupPreso(load_slides, prefix) {
 	preso_started = true;
 
   if (! cssPropertySupported('flex') ) {
+    // TODO: translate this this page!
     window.location = 'unsupported.html';
   }
 
@@ -92,6 +93,11 @@ function setupPreso(load_slides, prefix) {
   // yes, this is a global
   annotations = new Annotate();
 
+  // must be defined using [] syntax for a variable button name on IE.
+  var closeLabel      = I18n.t('help.close');
+  var buttons         = {};
+  buttons[closeLabel] = function() { $(this).dialog( "close" ); };
+
   $("#help-modal").dialog({
     autoOpen: false,
     dialogClass: "no-close",
@@ -100,11 +106,7 @@ function setupPreso(load_slides, prefix) {
     modal: true,
     resizable: false,
     width: 640,
-    buttons: {
-      Close: function() {
-        $( this ).dialog( "close" );
-      }
-    }
+    buttons: buttons
   });
 
   // wait until the presentation is loaded to hook up the previews.
@@ -310,7 +312,7 @@ function setupSideMenu() {
       var question = $("#question").val()
       var qid = askQuestion(question);
 
-      feedback_response(this, "Sending...");
+      feedback_response(this, I18n.t('menu.sending'));
       $("#question").val('');
 
       var questionItem = $('<li/>').text(question).attr('id', qid);
@@ -462,6 +464,32 @@ function setupMenu() {
   // can't use .children.replaceWith() because this starts out empty...
   $("#navigation").empty();
   $("#navigation").append(nav);
+}
+
+// this function generates an object that consumes the JSON form of translations
+// provided by the i18n gem. It provides pretty nearly the same calling syntax
+// as the Ruby library's dot-form.
+//
+// var I18n = new translation(data);
+// console.log(I18n.t('some.key.to.translate'));
+function translation(data) {
+  this.localized = data;
+  this.translate = function(key) {
+    var item = this.localized;
+    try {
+      key.split('.').forEach(function(val) {
+        item = item[val];
+      });
+      if(typeof(item) != 'string') {
+        item = null;
+      }
+    }
+    catch(e) {
+      item = null;
+    }
+    return item || ("No translation for " + key);
+  }
+  this.t = function(key) { return this.translate(key); }
 }
 
 // at some point this should get more sophisticated. Our needs are pretty minimal so far.
@@ -1297,7 +1325,7 @@ function toggleFollow()
   mode.follow = ! mode.follow;
 
   if(mode.follow) {
-    $("#followMode").show().text('Follow Mode:');
+    $("#followMode").show().text(I18n.t('follow.label'));
     getPosition();
   } else {
     $("#followMode").hide();
@@ -1419,11 +1447,10 @@ function toggleDebug () {
 
 function reloadSlides (hard) {
   if(hard) {
-    var message = 'Are you sure you want to reload Showoff?';
+    var message = I18n.t('reload');
   }
   else {
-    var message = "Are you sure you want to refresh the slide content?\n\n";
-    message    += '(Use `RELOAD` to fully reload the entire UI)';
+    var message = I18n.t('refresh');
   }
 
   if (confirm(message)) {
@@ -1589,7 +1616,7 @@ function togglePreShow() {
     }
 
   } else {
-    var seconds = parseFloat(prompt("Minutes from now to start") * 60);
+    var seconds = parseFloat(prompt(I18n.t('preshow.prompt')) * 60);
 
     try {
       slaveWindow.setupPreShow(seconds);
@@ -1648,7 +1675,7 @@ function startPreShow() {
 }
 
 function addPreShowTips(secondsLeft) {
-	$('#preshow_timer').text('Resuming in: ' + secondsToTime(secondsLeft));
+	$('#preshow_timer').text(I18n.t('preshow.resume') + ' ' + secondsToTime(secondsLeft));
 	var des = preshow_des && preshow_des[tmpImg.attr("ref")];
 	if(des) {
 		$('#tips').show();
@@ -1739,7 +1766,7 @@ function setupStats(data)
   if (viewers) {
     if (viewers.length == 1 && viewers[0][3] == 'current') {
       $("#viewers").removeClass('zoomline');
-      $("#viewers").text("All audience members are viewing the presenter's slide.");
+      $("#viewers").text(I18n.t('stats.allcurrent'));
     }
     else {
       $("#viewers").zoomline({

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -50,6 +50,7 @@ function setupPreso(load_slides, prefix) {
 	preso_started = true;
 
   if (! cssPropertySupported('flex') ) {
+    // TODO: translate this this page!
     window.location = 'unsupported.html';
   }
 
@@ -91,6 +92,11 @@ function setupPreso(load_slides, prefix) {
   // yes, this is a global
   annotations = new Annotate();
 
+  // must be defined using [] syntax for a variable button name on IE.
+  var closeLabel      = I18n.t('help.close');
+  var buttons         = {};
+  buttons[closeLabel] = function() { $(this).dialog( "close" ); };
+
   $("#help-modal").dialog({
     autoOpen: false,
     dialogClass: "no-close",
@@ -99,11 +105,7 @@ function setupPreso(load_slides, prefix) {
     modal: true,
     resizable: false,
     width: 640,
-    buttons: {
-      Close: function() {
-        $( this ).dialog( "close" );
-      }
-    }
+    buttons: buttons
   });
 
   // wait until the presentation is loaded to hook up the previews.
@@ -303,7 +305,7 @@ function setupSideMenu() {
       var question = $("#question").val()
       var qid = askQuestion(question);
 
-      feedback_response(this, "Sending...");
+      feedback_response(this, I18n.t('menu.sending'));
       $("#question").val('');
 
       var questionItem = $('<li/>').text(question).attr('id', qid);
@@ -455,6 +457,32 @@ function setupMenu() {
   // can't use .children.replaceWith() because this starts out empty...
   $("#navigation").empty();
   $("#navigation").append(nav);
+}
+
+// this function generates an object that consumes the JSON form of translations
+// provided by the i18n gem. It provides pretty nearly the same calling syntax
+// as the Ruby library's dot-form.
+//
+// var I18n = new translation(data);
+// console.log(I18n.t('some.key.to.translate'));
+function translation(data) {
+  this.localized = data;
+  this.translate = function(key) {
+    var item = this.localized;
+    try {
+      key.split('.').forEach(function(val) {
+        item = item[val];
+      });
+      if(typeof(item) != 'string') {
+        item = null;
+      }
+    }
+    catch(e) {
+      item = null;
+    }
+    return item || ("No translation for " + key);
+  }
+  this.t = function(key) { return this.translate(key); }
 }
 
 // at some point this should get more sophisticated. Our needs are pretty minimal so far.
@@ -1259,7 +1287,7 @@ function toggleFollow()
   mode.follow = ! mode.follow;
 
   if(mode.follow) {
-    $("#followMode").show().text('Follow Mode:');
+    $("#followMode").show().text(I18n.t('follow.label'));
     getPosition();
   } else {
     $("#followMode").hide();
@@ -1367,11 +1395,10 @@ function toggleDebug () {
 
 function reloadSlides (hard) {
   if(hard) {
-    var message = 'Are you sure you want to reload Showoff?';
+    var message = I18n.t('reload');
   }
   else {
-    var message = "Are you sure you want to refresh the slide content?\n\n";
-    message    += '(Use `RELOAD` to fully reload the entire UI)';
+    var message = I18n.t('refresh');
   }
 
   if (confirm(message)) {
@@ -1537,7 +1564,7 @@ function togglePreShow() {
     }
 
   } else {
-    var seconds = parseFloat(prompt("Minutes from now to start") * 60);
+    var seconds = parseFloat(prompt(I18n.t('preshow.prompt')) * 60);
 
     try {
       slaveWindow.setupPreShow(seconds);
@@ -1596,7 +1623,7 @@ function startPreShow() {
 }
 
 function addPreShowTips(secondsLeft) {
-	$('#preshow_timer').text('Resuming in: ' + secondsToTime(secondsLeft));
+	$('#preshow_timer').text(I18n.t('preshow.resume') + ' ' + secondsToTime(secondsLeft));
 	var des = preshow_des && preshow_des[tmpImg.attr("ref")];
 	if(des) {
 		$('#tips').show();
@@ -1687,7 +1714,7 @@ function setupStats(data)
   if (viewers) {
     if (viewers.length == 1 && viewers[0][3] == 'current') {
       $("#viewers").removeClass('zoomline');
-      $("#viewers").text("All audience members are viewing the presenter's slide.");
+      $("#viewers").text(I18n.t('stats.allcurrent'));
     }
     else {
       $("#viewers").zoomline({

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "htmlentities"
   s.add_dependency      "redcarpet"
   s.add_dependency      "nokogiri"
+  s.add_dependency      "i18n"
   s.add_dependency      "sinatra-websocket"
   # workaround a bad dependency in sinatra-websocket
   s.add_dependency      "thin", "~> 1.3"

--- a/views/404.erb
+++ b/views/404.erb
@@ -8,7 +8,7 @@
 <body id="download">
 
     <div id="preso">
-        <h1>File Not Found!</h1>
+        <h1><%= I18n.t('error.file_not_found') %></h1>
         <h2><%= @env['REQUEST_PATH'] %>
     </div>
     <div id="footer">

--- a/views/download.erb
+++ b/views/download.erb
@@ -6,8 +6,8 @@
 </head>
 
 <body id="download">
-  <div id="wrapper">  <!-- wrapper needed for presenterPopupToggle() and $.get() --> 
-  <h1>File Downloads</h1>
+  <div id="wrapper">  <!-- wrapper needed for presenterPopupToggle() and $.get() -->
+  <h1><%= I18n.t('downloads.title') %></h1>
   <% if @downloads %>
       <%# [ enabled, slide name, [array, of, files] ] %>
       <% @downloads.sort.map do |key, value| %>

--- a/views/header.erb
+++ b/views/header.erb
@@ -52,4 +52,6 @@
     keycode_dictionary   = <%= JSON.pretty_generate @keycode_dictionary %>;
     keycode_shifted_keys = <%= JSON.pretty_generate @keycode_shifted_keys %>;
 
+    I18n = new translation(<%= @language.to_json %>);
+
   </script>

--- a/views/help.erb
+++ b/views/help.erb
@@ -1,27 +1,27 @@
-<div id="help-modal" title="Help">
+<div id="help-modal" title="<%= I18n.t('help.title') %>">
   <div id="help">
     <div>
-      <span class="description">Move to the next slide.</span>
+      <span class="description"><%= I18n.t('help.next') %></span>
       <span class="action">NEXT</span>
       <span class="hotkeys"><%= mapped_keys('NEXT') %></span>
     </div>
     <div>
-      <span class="description">Move to the previous slide.</span>
+      <span class="description"><%= I18n.t('help.prev') %></span>
       <span class="action">PREV</span>
       <span class="hotkeys"><%= mapped_keys('PREV') %></span>
     </div>
     <div>
-      <span class="description">Show the table of contents menu.</span>
+      <span class="description"><%= I18n.t('help.contents') %></span>
       <span class="action">CONTENTS</span>
       <span class="hotkeys"><%= mapped_keys('CONTENTS') %></span>
     </div>
     <div>
-      <span class="description">Toggle follow mode.</span>
+      <span class="description"><%= I18n.t('help.follow') %></span>
       <span class="action">FOLLOW</span>
       <span class="hotkeys"><%= mapped_keys('FOLLOW') %></span>
     </div>
     <div>
-      <span class="description">Show this help dialog.</span>
+      <span class="description"><%= I18n.t('help.help') %></span>
       <span class="action">HELP</span>
       <span class="hotkeys"><%= mapped_keys('HELP') %></span>
     </div>
@@ -29,47 +29,47 @@
     <hr />
 
     <div>
-      <span class="description">Refresh slide content.</span>
+      <span class="description"><%= I18n.t('help.refresh') %></span>
       <span class="action">REFRESH</span>
       <span class="hotkeys"><%= mapped_keys('REFRESH') %></span>
     </div>
     <div>
-      <span class="description">Completely reload Showoff.</span>
+      <span class="description"><%= I18n.t('help.reload') %></span>
       <span class="action">RELOAD</span>
       <span class="hotkeys"><%= mapped_keys('RELOAD') %></span>
     </div>
     <div>
-      <span class="description">Blank the screen.</span>
+      <span class="description"><%= I18n.t('help.blank') %></span>
       <span class="action">BLANK</span>
       <span class="hotkeys"><%= mapped_keys('BLANK') %></span>
     </div>
     <div>
-      <span class="description">Toggle the display footer.</span>
+      <span class="description"><%= I18n.t('help.footer') %></span>
       <span class="action">FOOTER</span>
       <span class="hotkeys"><%= mapped_keys('FOOTER') %></span>
     </div>
     <div>
-      <span class="description">Toggle notes display.</span>
+      <span class="description"><%= I18n.t('help.notes') %></span>
       <span class="action">NOTES</span>
       <span class="hotkeys"><%= mapped_keys('NOTES') %></span>
     </div>
     <div>
-      <span class="description">Clear code execution results.</span>
+      <span class="description"><%= I18n.t('help.clear') %></span>
       <span class="action">CLEAR</span>
       <span class="hotkeys"><%= mapped_keys('CLEAR') %></span>
     </div>
     <div>
-      <span class="description">Pause the presentation.</span>
+      <span class="description"><%= I18n.t('help.pause') %></span>
       <span class="action">PAUSE</span>
       <span class="hotkeys"><%= mapped_keys('PAUSE') %></span>
     </div>
     <div>
-      <span class="description">Display slideshow of <tt>preshow</tt> images on a timer.</span>
+      <span class="description"><%= I18n.t('help.preshow') %></span>
       <span class="action">PRESHOW</span>
       <span class="hotkeys"><%= mapped_keys('PRESHOW') %></span>
     </div>
     <div>
-      <span class="description">Execute the first visible code block.</span>
+      <span class="description"><%= I18n.t('help.execute') %></span>
       <span class="action">EXECUTE</span>
       <span class="hotkeys"><%= mapped_keys('EXECUTE') %></span>
     </div>
@@ -77,7 +77,7 @@
     <hr />
 
     <div>
-      <span class="description">Show debugging information.</span>
+      <span class="description"><%= I18n.t('help.debug') %></span>
       <span class="action">DEBUG</span>
       <span class="hotkeys"><%= mapped_keys('DEBUG') %></span>
     </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -43,7 +43,7 @@
 
         <hr>
 
-        <div id="feedbackToggle" class="buttonWrapper interactive"><i class="fa fa-envelope"></i> <%= I18n.t('menu.feedback.title') %></div>
+        <div id="feedbackToggle" class="buttonWrapper interactive"><i class="fa fa-envelope"></i> <%= I18n.t('menu.feedback.label') %></div>
         <div id="feedbackSubmenu" class="submenu">
         <p><%= I18n.t('menu.feedback.label') %></p>
         <small>

--- a/views/index.erb
+++ b/views/index.erb
@@ -13,74 +13,74 @@
     <div id="navigationHover"></div>
     <div id="feedbackSidebar" class="sideMenu">
     <img id="disconnected" src="<%= @asset_path %>/css/disconnected.png">
-    <h3>Showoff Menu</h3>
-    <div id="navToggle" class="buttonWrapper"><i class=" fa fa-bookmark"></i> Table of Contents</div>
+    <h3><%= I18n.t('menu.title') %></h3>
+    <div id="navToggle" class="buttonWrapper"><i class=" fa fa-bookmark"></i> <%= I18n.t('menu.table_of_contents') %></div>
     <div id="navigation" class="submenu"></div>
     <% if not @static then %>
     <hr>
-    <div id="fileDownloads" class="buttonWrapper"><i class="fa fa-download"></i> Downloads</div>
+    <div id="fileDownloads" class="buttonWrapper"><i class="fa fa-download"></i> <%= I18n.t('menu.downloads') %></div>
     <% end %>
     <hr>
 
     <% if @feedback and not @static then %>
-        <p>The presenter should...</p>
+        <p><%= I18n.t('menu.pace.label') %></p>
         <div id="paceSlower" class="buttonWrapper split interactive">
         <i class="fa fa-minus"></i>
-        <br>Slow Down
+        <br><%= I18n.t('menu.pace.slower') %>
         </div>
         <div id="paceFaster" class="buttonWrapper split interactive">
         <i class="fa fa-plus"></i>
-        <br>Speed Up
+        <br><%= I18n.t('menu.pace.faster') %>
         </div>
 
         <hr>
-        <div id="questionToggle" class="buttonWrapper interactive"><i class="fa fa-hand-stop-o"></i> Ask a Question</div>
+        <div id="questionToggle" class="buttonWrapper interactive"><i class="fa fa-hand-stop-o"></i> <%= I18n.t('menu.question.label') %></div>
         <div id="questionSubmenu" class="submenu">
-        <textarea id="question" placeholder="Ask a question..."></textarea>
+        <textarea id="question" placeholder="<%= I18n.t('menu.question.placeholder') %>"></textarea>
         <div id="askQuestion" class="buttonWrapper interactive">Ask</div>
         </div>
         <ul id="askedQuestions"></ul>
 
         <hr>
 
-        <div id="feedbackToggle" class="buttonWrapper interactive"><i class="fa fa-envelope"></i> Send Feedback</div>
+        <div id="feedbackToggle" class="buttonWrapper interactive"><i class="fa fa-envelope"></i> <%= I18n.t('menu.feedback.title') %></div>
         <div id="feedbackSubmenu" class="submenu">
-        <p>This slide is...</p>
+        <p><%= I18n.t('menu.feedback.label') %></p>
         <small>
-            Terrible
+            <%= I18n.t('menu.feedback.worst') %>
             <input type="radio" name="rating" value="1"></input>
             <input type="radio" name="rating" value="2"></input>
             <input type="radio" name="rating" value="3"></input>
             <input type="radio" name="rating" value="4"></input>
             <input type="radio" name="rating" value="5"></input>
-            Awesome
+            <%= I18n.t('menu.feedback.best') %>
         </small>
-        <textarea id="feedback" placeholder="Why...?"></textarea>
-        <div id="sendFeedback" class="buttonWrapper interactive">Send</div>
+        <textarea id="feedback" placeholder="<%= I18n.t('menu.feedback.why') %>"></textarea>
+        <div id="sendFeedback" class="buttonWrapper interactive"><%= I18n.t('menu.feedback.send') %></div>
         </div>
 
         <% if @edit then %>
         <hr>
-        <div id="editSlide" class="buttonWrapper">Edit Current Slide</div>
+        <div id="editSlide" class="buttonWrapper"><%= I18n.t('menu.edit') %></div>
         <% end %>
         <hr>
-        <div id="clearAnnotations" class="buttonWrapper"><i class="fa fa-eraser"></i> Clear Annotations</div>
+        <div id="clearAnnotations" class="buttonWrapper"><i class="fa fa-eraser"></i> <%= I18n.t('menu.clear_annotations') %></div>
         <hr>
     <% end %>
 
-    <div id="closeMenu" class="buttonWrapper"><i class="fa fa-close"></i> Close</div>
+    <div id="closeMenu" class="buttonWrapper"><i class="fa fa-close"></i> <%= I18n.t('menu.close') %></div>
     <hr>
 
     <small>
-        <p>Press <code>?</code> for help.</p>
-        <p>All features are anonymous</p>
+        <p><%= I18n.t('menu.help') %></p>
+        <p><%= I18n.t('menu.anonymous') %></p>
     </small>
     </div>
     <div id="sidebarExit"></div>
 </div>
 <%= erb :help %>
 
-<div id="preso"><center>loading presentation...</center></div>
+<div id="preso"><center><%= I18n.t('loading') %></center></div>
 
 <div id="notes"></div>
 
@@ -97,7 +97,7 @@
 <%= @slides %>
 </div>
 <div id="buttonNav">
-  <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> Previous</div><div id="buttonNext">Next <i class="fa fa-chevron-right fa-lg"></i></div>
+  <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> <%= I18n.t('navigation.previous') %></div><div id="buttonNext"><%= I18n.t('navigation.next') %> <i class="fa fa-chevron-right fa-lg"></i></div>
 </div>
 <div id="pauseScreen">
   <%= @pause_msg %>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -24,30 +24,26 @@
 
     <span id="links">
       <span class="desktop">
-        <label for="annotationsToggle" class="no-mobile">Annotations <i class="fa fa-pencil"></i></label>
+        <label for="annotationsToggle" class="no-mobile" title="<%= I18n.t('presenter.topbar.tooltip.annotations') %>"><%= I18n.t('presenter.topbar.annotations') %> <i class="fa fa-pencil"></i></label>
         <input type="checkbox" id="annotationsToggle" autocomplete="off" class="no-mobile" />
 
         <% if @edit %>
-          <a id="edit" href="#" title="Edit current slide in new window.">Edit Slide <i class="fa fa-pencil-square-o"></i></a>
+          <a id="edit" href="#" title="<%= I18n.t('presenter.topbar.tooltip.edit') %>"><%= I18n.t('presenter.topbar.edit') %> <i class="fa fa-pencil-square-o"></i></a>
         <% end %>
         <% if @issues %>
-          <a id="report" href="javascript:reportIssue();" title="Report an issue with the current slide.">Report Issue With Slide <i class="fa fa-list-alt"></i></a>
+          <a id="report" href="javascript:reportIssue();" title="<%= I18n.t('presenter.topbar.tooltip.report') %>"><%= I18n.t('presenter.topbar.report') %> <i class="fa fa-list-alt"></i></a>
         <% end %>
 
-        <a id="statslink" href="">Viewing Statistics <i class="fa fa-chevron-down"></i></a>
-
-        <a id="downloadslink" href="">Downloads <i class="fa fa-chevron-down"></i></a>
-
-        <a id="slaveWindow" href="#" title="Enable the display window.">Display Window <i class="fa fa-clone"></i></a>
-
-        <a id="printSlides" href="#" title="Print slides using a new window.">Print Slides <i class="fa fa-print"></i></a>
-
-        <a id="settings" href="#">Settings <i class="fa fa-cog"></i></a>
+        <a id="statslink" href="" title="<%= I18n.t('presenter.topbar.tooltip.stats') %>"><%= I18n.t('presenter.topbar.stats') %> <i class="fa fa-chevron-down"></i></a>
+        <a id="downloadslink" href="" title="<%= I18n.t('presenter.topbar.tooltip.downloads') %>"><%= I18n.t('presenter.topbar.downloads') %> <i class="fa fa-chevron-down"></i></a>
+        <a id="slaveWindow" href="#" title="<%= I18n.t('presenter.topbar.tooltip.display') %>"><%= I18n.t('presenter.topbar.display') %> <i class="fa fa-clone"></i></a>
+        <a id="printSlides" href="#" title="<%= I18n.t('presenter.topbar.tooltip.print') %>"><%= I18n.t('presenter.topbar.print') %> <i class="fa fa-print"></i></a>
+        <a id="settings" href="#" title="<%= I18n.t('presenter.topbar.tooltip.settings') %>"><%= I18n.t('presenter.topbar.settings') %> <i class="fa fa-cog"></i></a>
       </span>
 
 
       <span class="mobile">
-        <a id="update" href="">Update</a>
+        <a id="update" href=""><%= I18n.t('presenter.mobile.update') %></a>
       </span>
     </span>
   </div>
@@ -55,12 +51,12 @@
   <div id="main">
     <div id="sidebar">
       <div id="timerSection">
-        <input type="button" id="pauseTimer" value="Pause" />
-        <input type="button" id="stopTimer" value="Cancel" />
-        <span id="timerLabel">Timer:</span>
+        <input type="button" id="pauseTimer" value="<%= I18n.t('presenter.timer.pause') %>" />
+        <input type="button" id="stopTimer" value="<%= I18n.t('presenter.timer.cancel') %>" />
+        <span id="timerLabel"><%= I18n.t('presenter.timer.label') %></span>
         <span id="minStart">
-          <input type="text" size="8" id="timerMinutes"/> min
-          <input type="button" id="startTimer" value="Start" />
+          <input type="text" size="4" id="timerMinutes"/> <%= I18n.t('presenter.timer.unit') %>
+          <input type="button" id="startTimer" value="<%= I18n.t('presenter.timer.start') %>" />
         </span>
         <div id="timerDisplay"></div>
       </div>
@@ -70,8 +66,8 @@
         <div class="gradient"> </div>
         <div class="left obscure"> </div>
         <div class="right obscure"> </div>
-        <span id="paceSlow">Speed Up!</span>
-        <span id="paceFast">Slow Down!</span>
+        <span id="paceSlow"><%= I18n.t('presenter.pace.faster') %></span>
+        <span id="paceFast"><%= I18n.t('presenter.pace.slower') %></span>
         <img id="paceMarker" src="<%= @asset_path %>/css/paceMarker.png" />
       </div>
       <% end %>
@@ -81,7 +77,7 @@
 
       <% if @feedback then %>
       <div id="questions">
-        <h3>Audience Questions</h3>
+        <h3><%= I18n.t('presenter.questions') %></h3>
         <ol id="unanswered"></ol>
         <ol id="answered"></ol>
       </div>
@@ -93,23 +89,23 @@
       <div id="frame">
         <div id="preview">
           <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
-          <div id="prevSlide" class="thumb"><div class="container"></div><h3 class="label">Previous</h3></div>
-          <div id="nextSlide" class="thumb"><div class="container"></div><h3 class="label">Next</h3></div>
-          <div id="preso">loading presentation...</div>
+          <div id="prevSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.previous') %></h3></div>
+          <div id="nextSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.next') %></h3></div>
+          <div id="preso"><%= I18n.t('loading') %></div>
         </div>
         <div id="annotationToolbar">
-          <label>Tools</label>
+          <label><%= I18n.t('presenter.annotation.tools') %></label>
             <i class="fa fa-pencil tool default active" data-action="draw" aria-hidden="true"></i>
             <i class="fa fa-arrow-right tool"  data-action="rightArrow" aria-hidden="true"></i>
             <i class="fa fa-arrow-left tool"  data-action="leftArrow" aria-hidden="true"></i>
             <i class="fa fa-bullseye tool" data-action="highlight" aria-hidden="true"></i>
             <i class="fa fa-eraser tool"  data-action="erase" aria-hidden="true"></i>
-          <label>Lines</label>
+          <label><%= I18n.t('presenter.annotation.lines') %></label>
             <i class="fa fa-square-o lines color1 active" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color2" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color3" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color4" aria-hidden="true"></i>
-          <label>Shapes</label>
+          <label><%= I18n.t('presenter.annotation.shapes') %></label>
             <i class="fa fa-square shapes color1" aria-hidden="true"></i>
             <i class="fa fa-square shapes color2" aria-hidden="true"></i>
             <i class="fa fa-square shapes color3 active" aria-hidden="true"></i>
@@ -118,7 +114,7 @@
       </div>
 
       <div id="statusbar">
-        <span class="label">Slide: <span id="slideInfo"></span></span>
+        <span class="label"><%= I18n.t('presenter.status.label') %> <span id="slideInfo"></span></span>
         <span id="debugInfo"></span>
         <span id="slideSource">
           <% if @request.host == 'localhost' %>
@@ -131,7 +127,7 @@
       <div id="progress" class="no-mobile"></div>
 
       <div id="buttonNav">
-        <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> Previous</div><div id="buttonNext">Next <i class="fa fa-chevron-right fa-lg"></i></div>
+        <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> <%= I18n.t('navigation.previous') %></div><div id="buttonNext"><%= I18n.t('navigation.next') %> <i class="fa fa-chevron-right fa-lg"></i></div>
       </div>
 
       <div id="notes-wrapper">
@@ -149,37 +145,37 @@
     </div><!-- end presenter -->
   </div><!-- end main -->
 
-  <div id="settings-modal" title="Settings">
-    <div id="enableFollower" class="setting" title="Send slide change notifications.">
-      <label for="followerToggle">Update Follower</label><input type="checkbox" id="followerToggle" autocomplete="off" checked />
+  <div id="settings-modal" title="<%= I18n.t('presenter.settings.label') %>">
+    <div id="enableFollower" class="setting" title="<%= I18n.t('presenter.settings.follower.tooltip') %>">
+      <label for="followerToggle"><%= I18n.t('presenter.settings.follower.label') %></label><input type="checkbox" id="followerToggle" autocomplete="off" checked />
       <p class="description">
-        When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+        <%= I18n.t('presenter.settings.follower.description') %>
       </p>
     </div>
-    <div id="enableRemote" class="setting" title="Enables tracking of other presenters.">
-      <label for="remoteToggle">Enable Remote</label><input type="checkbox" id="remoteToggle" autocomplete="off" checked />
+    <div id="enableRemote" class="setting" title="<%= I18n.t('presenter.settings.remote.tooltip') %>">
+      <label for="remoteToggle"><%= I18n.t('presenter.settings.remote.label') %></label><input type="checkbox" id="remoteToggle" autocomplete="off" checked />
       <p class="description">
-        When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+        <%= I18n.t('presenter.settings.follower.description') %>
       </p>
     </div>
     <div class="setting">
-      <label>Layout</label><br>
+      <label><%= I18n.t('presenter.settings.layout.label') %></label><br>
       <select id="layoutSelector" autocomplete="off">
-        <option value="default" selected>Default Layout</option>
-        <option value="thumbs"   title="Display thumbnail previews of the next and previous slides.">Thumbnails</option>
-        <option value="floating" title="Open the next slide as a floating window.">Floating</option>
-        <option value="beside"   title="Display the next slide as a large preview in the main presenter view.">Side-by-Side</option>
+        <option value="default" selected><%= I18n.t('presenter.settings.layout.default') %></option>
+        <option value="thumbs"   title="<%= I18n.t('presenter.settings.layout.thumbs') %>">Thumbnails</option>
+        <option value="floating" title="<%= I18n.t('presenter.settings.layout.floating') %>">Floating</option>
+        <option value="beside"   title="<%= I18n.t('presenter.settings.layout.beside') %>">Side-by-Side</option>
       </select>
       <div id="nextWindowConfirmation">
-        <p class="description">Browser security requires confirmation before opening a new window.</p>
+        <p class="description"><%= I18n.t('presenter.settings.layout.confirmation') %></p>
         <p>
-          <input id="openNextWindow" type="button" onClick="#" value="Open Window" />
-          <a id="nextWinCancel" href="#">cancel</a>
+          <input id="openNextWindow" type="button" onClick="#" value="<%= I18n.t('presenter.settings.layout.open') %>" />
+          <a id="nextWinCancel" href="#"><%= I18n.t('presenter.settings.layout.cancel') %></a>
         </p>
       </div>
     </div>
     <div class="links">
-      <a id="clearCookies" href="#" title="Reset Showoff UI settings to default values.">Clear Showoff settings.</a>
+      <a id="clearCookies" href="#" title="<%= I18n.t('presenter.settings.layout.reset.tooltip') %>"><%= I18n.t('presenter.settings.layout.reset.label') %></a>
     </div>
   </div>
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -24,30 +24,26 @@
 
     <span id="links">
       <span class="desktop">
-        <label for="annotationsToggle" class="no-mobile">Annotations <i class="fa fa-pencil"></i></label>
+        <label for="annotationsToggle" class="no-mobile" title="<%= I18n.t('presenter.topbar.tooltip.annotations') %>"><%= I18n.t('presenter.topbar.annotations') %> <i class="fa fa-pencil"></i></label>
         <input type="checkbox" id="annotationsToggle" autocomplete="off" class="no-mobile" />
 
         <% if @edit %>
-          <a id="edit" href="#" title="Edit current slide in new window.">Edit Slide <i class="fa fa-pencil-square-o"></i></a>
+          <a id="edit" href="#" title="<%= I18n.t('presenter.topbar.tooltip.edit') %>"><%= I18n.t('presenter.topbar.edit') %> <i class="fa fa-pencil-square-o"></i></a>
         <% end %>
         <% if @issues %>
-          <a id="report" href="javascript:reportIssue();" title="Report an issue with the current slide.">Report Issue With Slide <i class="fa fa-list-alt"></i></a>
+          <a id="report" href="javascript:reportIssue();" title="<%= I18n.t('presenter.topbar.tooltip.report') %>"><%= I18n.t('presenter.topbar.report') %> <i class="fa fa-list-alt"></i></a>
         <% end %>
 
-        <a id="statslink" href="">Viewing Statistics <i class="fa fa-chevron-down"></i></a>
-
-        <a id="downloadslink" href="">Downloads <i class="fa fa-chevron-down"></i></a>
-
-        <a id="slaveWindow" href="#" title="Enable the display window.">Display Window <i class="fa fa-clone"></i></a>
-
-        <a id="printSlides" href="#" title="Print slides using a new window.">Print Slides <i class="fa fa-print"></i></a>
-
-        <a id="settings" href="#">Settings <i class="fa fa-cog"></i></a>
+        <a id="statslink" href="" title="<%= I18n.t('presenter.topbar.tooltip.stats') %>"><%= I18n.t('presenter.topbar.stats') %> <i class="fa fa-chevron-down"></i></a>
+        <a id="downloadslink" href="" title="<%= I18n.t('presenter.topbar.tooltip.downloads') %>"><%= I18n.t('presenter.topbar.downloads') %> <i class="fa fa-chevron-down"></i></a>
+        <a id="slaveWindow" href="#" title="<%= I18n.t('presenter.topbar.tooltip.display') %>"><%= I18n.t('presenter.topbar.display') %> <i class="fa fa-clone"></i></a>
+        <a id="printSlides" href="#" title="<%= I18n.t('presenter.topbar.tooltip.print') %>"><%= I18n.t('presenter.topbar.print') %> <i class="fa fa-print"></i></a>
+        <a id="settings" href="#" title="<%= I18n.t('presenter.topbar.tooltip.settings') %>"><%= I18n.t('presenter.topbar.settings') %> <i class="fa fa-cog"></i></a>
       </span>
 
 
       <span class="mobile">
-        <a id="update" href="">Update</a>
+        <a id="update" href=""><%= I18n.t('presenter.mobile.update') %></a>
       </span>
     </span>
   </div>
@@ -55,23 +51,23 @@
   <div id="main">
     <div id="sidebar">
       <div id="timerSection">
-        <input type="button" id="pauseTimer" value="Pause" />
-        <input type="button" id="stopTimer" value="Cancel" />
-        <span id="timerLabel">Timer:</span>
+        <input type="button" id="pauseTimer" value="<%= I18n.t('presenter.timer.pause') %>" />
+        <input type="button" id="stopTimer" value="<%= I18n.t('presenter.timer.cancel') %>" />
+        <span id="timerLabel"><%= I18n.t('presenter.timer.label') %></span>
         <span id="minStart">
-          <input type="text" size="8" id="timerMinutes"/> min
-          <input type="button" id="startTimer" value="Start" />
+          <input type="text" size="4" id="timerMinutes"/> <%= I18n.t('presenter.timer.unit') %>
+          <input type="button" id="startTimer" value="<%= I18n.t('presenter.timer.start') %>" />
         </span>
         <div id="timerDisplay"></div>
       </div>
 
-      <% if @feedback and not @static then %>
+      <% if @feedback then %>
       <div id="feedbackPace">
         <div class="gradient"> </div>
         <div class="left obscure"> </div>
         <div class="right obscure"> </div>
-        <span id="paceSlow">Speed Up!</span>
-        <span id="paceFast">Slow Down!</span>
+        <span id="paceSlow"><%= I18n.t('presenter.pace.faster') %></span>
+        <span id="paceFast"><%= I18n.t('presenter.pace.slower') %></span>
         <img id="paceMarker" src="<%= @asset_path %>/css/paceMarker.png" />
       </div>
       <% end %>
@@ -79,9 +75,9 @@
       <div id="navigation" class="submenu"></div>
       <div id="navigationHover"></div>
 
-      <% if @feedback and not @static then %>
+      <% if @feedback then %>
       <div id="questions">
-        <h3>Audience Questions</h3>
+        <h3><%= I18n.t('presenter.questions') %></h3>
         <ol id="unanswered"></ol>
         <ol id="answered"></ol>
       </div>
@@ -93,23 +89,23 @@
       <div id="frame">
         <div id="preview">
           <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
-          <div id="prevSlide" class="thumb"><div class="container"></div><h3 class="label">Previous</h3></div>
-          <div id="nextSlide" class="thumb"><div class="container"></div><h3 class="label">Next</h3></div>
-          <div id="preso">loading presentation...</div>
+          <div id="prevSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.previous') %></h3></div>
+          <div id="nextSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.next') %></h3></div>
+          <div id="preso"><%= I18n.t('loading') %></div>
         </div>
         <div id="annotationToolbar">
-          <label>Tools</label>
+          <label><%= I18n.t('presenter.annotation.tools') %></label>
             <i class="fa fa-pencil tool default active" data-action="draw" aria-hidden="true"></i>
             <i class="fa fa-arrow-right tool"  data-action="rightArrow" aria-hidden="true"></i>
             <i class="fa fa-arrow-left tool"  data-action="leftArrow" aria-hidden="true"></i>
             <i class="fa fa-bullseye tool" data-action="highlight" aria-hidden="true"></i>
             <i class="fa fa-eraser tool"  data-action="erase" aria-hidden="true"></i>
-          <label>Lines</label>
+          <label><%= I18n.t('presenter.annotation.lines') %></label>
             <i class="fa fa-square-o lines color1 active" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color2" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color3" aria-hidden="true"></i>
             <i class="fa fa-square-o lines color4" aria-hidden="true"></i>
-          <label>Shapes</label>
+          <label><%= I18n.t('presenter.annotation.shapes') %></label>
             <i class="fa fa-square shapes color1" aria-hidden="true"></i>
             <i class="fa fa-square shapes color2" aria-hidden="true"></i>
             <i class="fa fa-square shapes color3 active" aria-hidden="true"></i>
@@ -118,7 +114,7 @@
       </div>
 
       <div id="statusbar">
-        <span class="label">Slide: <span id="slideInfo"></span></span>
+        <span class="label"><%= I18n.t('presenter.status.label') %> <span id="slideInfo"></span></span>
         <span id="debugInfo"></span>
         <span id="slideSource">
           <% if @request.host == 'localhost' %>
@@ -131,7 +127,7 @@
       <div id="progress" class="no-mobile"></div>
 
       <div id="buttonNav">
-        <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> Previous</div><div id="buttonNext">Next <i class="fa fa-chevron-right fa-lg"></i></div>
+        <div id="buttonPrev"><i class="fa fa-chevron-left fa-lg"></i> <%= I18n.t('navigation.previous') %></div><div id="buttonNext"><%= I18n.t('navigation.next') %> <i class="fa fa-chevron-right fa-lg"></i></div>
       </div>
 
       <div id="notes-wrapper">
@@ -149,37 +145,37 @@
     </div><!-- end presenter -->
   </div><!-- end main -->
 
-  <div id="settings-modal" title="Settings">
-    <div id="enableFollower" class="setting" title="Send slide change notifications.">
-      <label for="followerToggle">Update Follower</label><input type="checkbox" id="followerToggle" autocomplete="off" checked />
+  <div id="settings-modal" title="<%= I18n.t('presenter.settings.label') %>">
+    <div id="enableFollower" class="setting" title="<%= I18n.t('presenter.settings.follower.tooltip') %>">
+      <label for="followerToggle"><%= I18n.t('presenter.settings.follower.label') %></label><input type="checkbox" id="followerToggle" autocomplete="off" checked />
       <p class="description">
-        When this is enabled, the Showoff server will track your slide changes. Disable it to observe the presentation without inadvertently causing slide changes.
+        <%= I18n.t('presenter.settings.follower.description') %>
       </p>
     </div>
-    <div id="enableRemote" class="setting" title="Enables tracking of other presenters.">
-      <label for="remoteToggle">Enable Remote</label><input type="checkbox" id="remoteToggle" autocomplete="off" checked />
+    <div id="enableRemote" class="setting" title="<%= I18n.t('presenter.settings.remote.tooltip') %>">
+      <label for="remoteToggle"><%= I18n.t('presenter.settings.remote.label') %></label><input type="checkbox" id="remoteToggle" autocomplete="off" checked />
       <p class="description">
-        When this is enabled, you can load the presenter in another browser (typically on your mobile phone) to control the presentation.
+        <%= I18n.t('presenter.settings.follower.description') %>
       </p>
     </div>
     <div class="setting">
-      <label>Layout</label><br>
+      <label><%= I18n.t('presenter.settings.layout.label') %></label><br>
       <select id="layoutSelector" autocomplete="off">
-        <option value="default" selected>Default Layout</option>
-        <option value="thumbs"   title="Display thumbnail previews of the next and previous slides.">Thumbnails</option>
-        <option value="floating" title="Open the next slide as a floating window.">Floating</option>
-        <option value="beside"   title="Display the next slide as a large preview in the main presenter view.">Side-by-Side</option>
+        <option value="default" selected><%= I18n.t('presenter.settings.layout.default') %></option>
+        <option value="thumbs"   title="<%= I18n.t('presenter.settings.layout.thumbs') %>">Thumbnails</option>
+        <option value="floating" title="<%= I18n.t('presenter.settings.layout.floating') %>">Floating</option>
+        <option value="beside"   title="<%= I18n.t('presenter.settings.layout.beside') %>">Side-by-Side</option>
       </select>
       <div id="nextWindowConfirmation">
-        <p class="description">Browser security requires confirmation before opening a new window.</p>
+        <p class="description"><%= I18n.t('presenter.settings.layout.confirmation') %></p>
         <p>
-          <input id="openNextWindow" type="button" onClick="#" value="Open Window" />
-          <a id="nextWinCancel" href="#">cancel</a>
+          <input id="openNextWindow" type="button" onClick="#" value="<%= I18n.t('presenter.settings.layout.open') %>" />
+          <a id="nextWinCancel" href="#"><%= I18n.t('presenter.settings.layout.cancel') %></a>
         </p>
       </div>
     </div>
     <div class="links">
-      <a id="clearCookies" href="#" title="Reset Showoff UI settings to default values.">Clear Showoff settings.</a>
+      <a id="clearCookies" href="#" title="<%= I18n.t('presenter.settings.layout.reset.tooltip') %>"><%= I18n.t('presenter.settings.layout.reset.label') %></a>
     </div>
   </div>
 

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -16,13 +16,13 @@
         });
     </script>
 
-    <h1>Viewing Statistics</h1>
-    <p id="stray"><span class="label"></span> of your audience is not viewing the same slide you are.</p>
-    <p id="idle"><span class="label"></span> of your audience is idle.</p>
-    <h2>Slides currently being viewed:</h2>
-    <div id="viewers">No data to display.</div>
-    <h2>Elapsed time spent on each slide:</h2>
-    <div id="elapsed">No data to display.</div>
+    <h1><%= I18n.t('stats.title') %></h1>
+    <p id="stray"><span class="label"></span> <%= I18n.t('stats.stray') %></p>
+    <p id="idle"><span class="label"></span> <%= I18n.t('stats.idle') %></p>
+    <h2><%= I18n.t('stats.current') %></h2>
+    <div id="viewers"><%= I18n.t('stats.nodata') %></div>
+    <h2><%= I18n.t('stats.elapsed') %></h2>
+    <div id="elapsed"><%= I18n.t('stats.nodata') %></div>
   </div>
 
   <div id="all">


### PR DESCRIPTION
This provides an internationalization framework. Two kinds of translations are provided for:

* Strings in the Showoff UI are translated based on built in string files.
* Translated versions of the presentation can be served, if they exist.

All translation is keyed off the language setting in the viewer's browser. In other words, if the viewer's language is set to French, then the French version of the Showoff UI will be displayed. This also applies to content. If there is a German translation, and the viewer's browser is set to German, then the German content will be served. Fallbacks are provided.

This means that an English presentation can be displayed on the projector, but viewers can see localized versions in their own browsers.

The Japanese translation is currently incomplete, but I wanted to get this in front of some eyeballs. Some of the interface elements do not accommodate the longer strings and will take some work.