### PR TITLE
Move the dummy websocket to ensure it's always available

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -26,6 +26,10 @@ var loadSlidesPrefix
 
 var mode = { track: true, follow: true };
 
+// a dummy websocket object to make standalone presentations easier.
+var ws = {}
+ws.send = function() { /* no-op */ }
+
 // since javascript doesn't have a built-in way to get to cookies easily,
 // let's just add our own data structure.
 document.cookieHash = {}
@@ -956,10 +960,6 @@ function connectControlChannel() {
     ws.onopen    = function()  { connected();          };
     ws.onclose   = function()  { disconnected();       }
     ws.onmessage = function(m) { parseMessage(m.data); };
-  }
-  else {
-    ws = {}
-    ws.send = function() { /* no-op */ }
   }
 }
 


### PR DESCRIPTION
This is initialized early so that when running a presentation in
standalone mode it won't fail with an u ninitialized variable.