### PR TITLE
Adds active styling to menu items

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -50,6 +50,11 @@
   #topbar .ui-widget:hover {
     background-color: #263238;
   }
+  #topbar a:active,
+  #topbar a.enabled:active,
+  #topbar .ui-widget:active {
+    background-color: #2e424c;
+  }
 
   #close-sidebar {
     padding: .25em;
@@ -106,13 +111,14 @@
   display: none;
   position: absolute;
   z-index: 2147483647;
-  top: 3em;
+  top: 2.95em;
   left: 25%;
   max-height: 80%;
   width: 50%;
   padding-bottom: 1em;
   border-radius: 0 0 .5em .5em;
   overflow: auto;
+  background-color: #263238;
 }
 
   #presenterPopup a {

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -201,12 +201,17 @@ $(document).ready(function(){
 
 function presenterPopupToggle(page, event) {
   event.preventDefault();
+  // remove class from both so we don't lose an active state if user clicks the wrong item
+  $('#statslink').removeClass('enabled');
+  $('#downloadslink').removeClass('enabled');
+
   var popup = $('#presenterPopup');
   if (popup.length > 0) {
     popup.slideUp(200, function () {
       popup.remove();
     });
   } else {
+    $(event.target).addClass('enabled');
     popup = $('<div>');
     popup.attr('id', 'presenterPopup');
     $.get(page, function(data) {


### PR DESCRIPTION
This makes it easier for users to correlate what they clicked with what
happened and visual confirmation that their click actually registered.

<img width="671" alt="screen shot 2017-04-13 at 3 59 41 pm" src="https://cloud.githubusercontent.com/assets/1392917/25027545/4543aebc-2062-11e7-927d-9f37946291ca.png">