### PR TITLE
Remove display view reopen polling

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -288,7 +288,7 @@ function openSlave()
 
       // call back and update the parent presenter if the window is closed
       slaveWindow.onunload = function(e) {
-        slaveWindow.opener.closeSlave(false);
+        slaveWindow.opener.closeSlave(true);
       };
     }, 500);
 
@@ -299,18 +299,28 @@ function openSlave()
   }
 }
 
-function closeSlave(closeWindow) {
+function closeSlave(calledByChild) {
   try {
     mode.slave = false;
     $('#slaveWindow').removeClass('enabled');
 
-    if(closeWindow != false) {
+    if(calledByChild) {
+      // if this is called by the display view, we don't want to try to close it again.
+      // browsers are the worst. If the user hit *refresh*, then this should reconnect the display view
+      window.setTimeout(function() {
+        if(! windowIsClosed(slaveWindow)) {
+          openSlave();
+        }
+      }, 500);
+    } else {
+      // called normally and close the display view
       slaveWindow && slaveWindow.close();
     }
   }
   catch (e) {
     console.log('Display window failed to close properly.');
   }
+
 }
 
 function nextSlideNum(url) {


### PR DESCRIPTION
This was foolish to begin with. Calling back to disconnect is a much
more reasonable way to do this. Also, for unexplained reasons, the loop
was triggering terrible side effects, like throwing the display view
into a reload loop when the edit link was clicked!

Fixes #746