### PR TITLE
Track the "master" presenter

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -149,6 +149,7 @@ $(document).ready(function(){
   $('#followerToggle').change( toggleUpdater );
   $('#annotationsToggle').change( toggleAnnotations );
 
+  initializeSettings();
   setInterval(function() { updatePace() }, 1000);
 
   setInterval(function() {
@@ -890,6 +891,12 @@ function stopTimer() {
 
   // only unpin when the user has dismissed the timer
   unpinSidebar('timer');
+}
+
+function initializeSettings() {
+  // enable this if we are the "master" presenter
+  $("#followerToggle").prop("checked", master);
+  mode.update = $("#followerToggle").prop("checked");
 }
 
 /********************

--- a/views/header.erb
+++ b/views/header.erb
@@ -47,6 +47,7 @@
 
     editUrl     = "<%= @edit %>";
     interactive = <%= @interactive %>;
+    master      = <%= master_presenter? %>;
 
     keymap               = <%= JSON.pretty_generate @keymap %>;
     keycode_dictionary   = <%= JSON.pretty_generate @keycode_dictionary %>;


### PR DESCRIPTION
The first browser that loads the presenter view is recorded as the
"master". Any other browsers that load it will default to not updating
the follower. This is useful, for example, if you have a second
presenter observing the presentation.

You can still enable this from the secondary presenters, it just
defaults to off.