### PR TITLE
Add content language chooser

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1182,7 +1182,7 @@ class ShowOff < Sinatra::Application
       @language = get_translations()
 
       # store a cookie to tell clients apart. More reliable than using IP due to proxies, etc.
-      ensure_client_id()
+      manage_client_cookies()
 
       erb :index
     end
@@ -1194,10 +1194,7 @@ class ShowOff < Sinatra::Application
       @feedback  = settings.showoff_config['feedback']
       @language  = get_translations()
 
-      ensure_client_id()
-      @@master ||= @client_id
-      @@cookie ||= guid()
-      response.set_cookie('presenter', @@cookie)
+      manage_client_cookies(true)
 
       erb :presenter
     end
@@ -1598,7 +1595,7 @@ class ShowOff < Sinatra::Application
     @@master == @client_id
   end
 
-  def ensure_client_id
+  def manage_client_cookies(presenter=false)
     # store a cookie to tell clients apart. More reliable than using IP due to proxies, etc.
     if request.nil?   # when running showoff static
       @client_id = guid()
@@ -1609,6 +1606,15 @@ class ShowOff < Sinatra::Application
         @client_id = guid()
         response.set_cookie('client_id', @client_id)
       end
+    end
+
+    # if we have no content translations then remove the cookie
+    response.delete_cookie('locale') if language_names.empty?
+
+    if presenter
+      @@master ||= @client_id
+      @@cookie ||= guid()
+      response.set_cookie('presenter', @@cookie)
     end
   end
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -13,6 +13,7 @@ require 'i18n'
 require 'i18n/backend/fallbacks'
 require 'rack'
 require 'rack/contrib'
+require 'iso-639'
 
 here = File.expand_path(File.dirname(__FILE__))
 require "#{here}/showoff_utils"
@@ -275,27 +276,61 @@ class ShowOff < Sinatra::Application
       end
     end
 
+    # This is just a unified lookup method that takes a full locale name
+    # and then resolves it to an available version of the name
+    def with_locale(locale)
+      locale = locale.to_s
+      until (locale.empty?) do
+        result = yield(locale)
+        return result unless result.nil?
+
+        # if not found, chop off a section and try again
+        locale = locale.rpartition(/[-_]/).first
+      end
+    end
+
+    # turns a locale code into a string name
+    def get_language_name(locale)
+      with_locale(locale) do |str|
+        result = ISO_639.find(str)
+        result[3] unless result.nil?
+      end
+    end
+
     # This function returns the directory containing translated *content*, defaulting
     # to cwd. This works similarly to I18n fallback, but we cannot reuse that as it's
     # a different translation mechanism.
-    def get_locale_dir(prefix)
-      locale = I18n.locale.to_s
+    def get_locale_dir(prefix, locale)
+      return '.' if locale == 'disable'
 
-      until (locale.empty?) do
-        path = "#{prefix}/#{locale}"
+      with_locale(locale) do |str|
+        path = "#{prefix}/#{str}"
         return path if File.directory?(path)
+      end || '.'
+    end
 
-        # if not found, chop off a section and try again
-        locale = locale.rpartition('-').first
+    # return a hash of all language codes available and the long name description of each
+    def language_names
+      Dir.glob('locales/*').inject({}) do |memo, entry|
+        locale = File.basename(entry)
+        memo.update(locale => get_language_name(locale))
       end
-      '.'
     end
 
-    def locale
-      languages = I18n.backend.send(:translations)
-      I18n.fallbacks[I18n.locale].select { |f| languages.keys.include? f }.first
+    # returns the minimized canonical version of the current selected content locale
+    # it assumes that if the user has specified a locale, that it's already minimized
+    # note: if the locale doesn't exist on disk, it will just default to no translation
+    def locale(user_locale)
+      if [nil, '', 'auto'].include? user_locale
+        languages = I18n.available_locales
+        I18n.fallbacks[I18n.locale].select { |f| languages.include? f }.first
+      else
+        user_locale
+      end
     end
 
+    # returns a hash of all translations for the current language. This is used
+    # for the javascript half of the translations
     def get_translations
       languages = I18n.backend.send(:translations)
       fallback  = I18n.fallbacks[I18n.locale].select { |f| languages.keys.include? f }.first
@@ -1055,7 +1090,7 @@ class ShowOff < Sinatra::Application
 
     def get_slides_html(opts={:static=>false, :pdf=>false, :toc=>false, :supplemental=>nil, :section=>nil})
       sections = nil
-      Dir.chdir(get_locale_dir('locales')) do
+      Dir.chdir(get_locale_dir('locales', @locale)) do
         sections = ShowOffUtils.showoff_sections(settings.pres_dir, settings.showoff_config, @logger)
       end
 
@@ -1836,7 +1871,7 @@ class ShowOff < Sinatra::Application
 
   # gawd, this whole routing scheme is bollocks
   get %r{/([^/]*)/?([^/]*)} do
-    @locale    = locale()
+    @locale    = locale(request.cookies['locale'])
     @title     = ShowOffUtils.showoff_title(settings.pres_dir)
     @pause_msg = ShowOffUtils.pause_msg
     what = params[:captures].first

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -140,6 +140,12 @@ en:
         reset:
           label: Clear Showoff settings.
           tooltip: Reset Showoff UI settings to default values.
+      language:
+        label: Content Language
+        tooltip: Select from available translations, or autoselect based on your browser settings.
+        description: This presentation is available in different languages. Choose the language you would like to view or leave it at <tt>automatic</tt> to use your browser settings.
+        auto: Automatic
+        disable: Disable translations
 
   error:
     file_not_found: File Not Found!

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -21,6 +21,7 @@ en:
       send: Send
     edit: Edit Current Slide
     clear_annotations: Clear Annotations
+    language: Content Language
     close: Close
     help: Press <code>?</code> for help.
     anonymous: All features are anonymous.
@@ -144,8 +145,10 @@ en:
         label: Content Language
         tooltip: Select from available translations, or autoselect based on your browser settings.
         description: This presentation is available in different languages. Choose the language you would like to view or leave it at <tt>automatic</tt> to use your browser settings.
-        auto: Automatic
-        disable: Disable translations
+
+  language:
+    auto: Automatic
+    disable: Disable Translations
 
   error:
     file_not_found: File Not Found!

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -386,6 +386,7 @@ img#disconnected {
   clear: both;
 }
 
+.optionWrapper,
 .buttonWrapper {
   line-height: 48px;
   padding: 0 16px;
@@ -508,6 +509,10 @@ img#disconnected {
   text-decoration: line-through;
   color: #ccc;
 }
+#languageMenu {
+  line-height: 2em;
+}
+
 
 /* End Sidebar styling */
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -46,11 +46,10 @@ $(document).ready(function(){
   $('#statslink').click(function(e) { presenterPopupToggle('/stats', e); });
   $('#downloadslink').click(function(e) { presenterPopupToggle('/download', e); });
 
-  $('#languageSelector').change(function(e) { chooseLanguage(e.target.value); });
   $('#layoutSelector').change(function(e) { chooseLayout(e.target.value); });
-
-  chooseLanguage(null);
   chooseLayout(null);
+
+  // the language selector is configured in showoff.js
 
   // must be defined using [] syntax for a variable button name on IE.
   var closeLabel      = I18n.t('presenter.settings.close');

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -46,8 +46,10 @@ $(document).ready(function(){
   $('#statslink').click(function(e) { presenterPopupToggle('/stats', e); });
   $('#downloadslink').click(function(e) { presenterPopupToggle('/download', e); });
 
+  $('#languageSelector').change(function(e) { chooseLanguage(e.target.value); });
   $('#layoutSelector').change(function(e) { chooseLayout(e.target.value); });
 
+  chooseLanguage(null);
   chooseLayout(null);
 
   // must be defined using [] syntax for a variable button name on IE.

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -73,7 +73,11 @@ function setupPreso(load_slides, prefix) {
 
   setupSideMenu();
 
-	doDebugStuff();
+  // Set up the language selector
+  $('#languageSelector').change(function(e) { chooseLanguage(e.target.value); });
+  chooseLanguage(null);
+
+  doDebugStuff();
 
 	// bind event handlers
 	toggleKeybinding('on');
@@ -508,7 +512,7 @@ function translation(data) {
 
 function chooseLanguage(locale) {
   // yay for half-baked data storage schemes
-  newlocale = locale || document.cookieHash['locale'] || 'automatic';
+  newlocale = locale || document.cookieHash['locale'] || 'auto';
 
   if(locale){
     document.cookie = "locale="+newlocale;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -506,9 +506,22 @@ function translation(data) {
   this.t = function(key) { return this.translate(key); }
 }
 
+function chooseLanguage(locale) {
+  // yay for half-baked data storage schemes
+  newlocale = locale || document.cookieHash['locale'] || 'automatic';
+
+  if(locale){
+    document.cookie = "locale="+newlocale;
+    location.reload(false);
+  } else {
+    $('#languageSelector').val(newlocale);
+  }
+}
+
 // at some point this should get more sophisticated. Our needs are pretty minimal so far.
 function clearCookies() {
   document.cookie = "sidebar=;expires=Thu, 21 Sep 1979 00:00:01 UTC;";
+  document.cookie = "locale=;expires=Thu, 21 Sep 1979 00:00:01 UTC;";
   document.cookie = "layout=;expires=Thu, 21 Sep 1979 00:00:01 UTC;";
   document.cookie = "notes=;expires=Thu, 21 Sep 1979 00:00:01 UTC;";
 }

--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "redcarpet"
   s.add_dependency      "nokogiri"
   s.add_dependency      "i18n"
+  s.add_dependency      "iso-639"
   s.add_dependency      "sinatra-websocket"
   # workaround a bad dependency in sinatra-websocket
   s.add_dependency      "thin", "~> 1.3"

--- a/views/index.erb
+++ b/views/index.erb
@@ -68,6 +68,20 @@
         <hr>
     <% end %>
 
+    <% unless language_names.empty? %>
+    <div id="languageMenu" class="optionWrapper">
+      <i class="fa fa-language" aria-hidden="true"></i> <%= I18n.t('menu.language') %>
+      <select id="languageSelector" autocomplete="off">
+        <option value="auto" selected><%= I18n.t('language.auto') %></option>
+        <% language_names.each do |code, name| %>
+        <option value="<%= code %>"><%= name %></option>
+        <% end %>
+        <option value="disable"><%= I18n.t('language.disable') %></option>
+      </select>
+    </div>
+    <hr>
+    <% end %>
+
     <div id="closeMenu" class="buttonWrapper"><i class="fa fa-close"></i> <%= I18n.t('menu.close') %></div>
     <hr>
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -164,11 +164,11 @@
     <div class="setting">
       <label><%= I18n.t('presenter.settings.language.label') %></label><br>
       <select id="languageSelector" autocomplete="off">
-        <option value="auto" selected><%= I18n.t('presenter.settings.language.auto') %></option>
+        <option value="auto" selected><%= I18n.t('language.auto') %></option>
         <% language_names.each do |code, name| %>
         <option value="<%= code %>"><%= name %></option>
         <% end %>
-        <option value="disable"><%= I18n.t('presenter.settings.language.disable') %></option>
+        <option value="disable"><%= I18n.t('language.disable') %></option>
       </select>
       <p class="description">
         <%= I18n.t('presenter.settings.language.description') %>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -160,6 +160,21 @@
         <%= I18n.t('presenter.settings.remote.description') %>
       </p>
     </div>
+    <% unless language_names.empty? %>
+    <div class="setting">
+      <label><%= I18n.t('presenter.settings.language.label') %></label><br>
+      <select id="languageSelector" autocomplete="off">
+        <option value="auto" selected><%= I18n.t('presenter.settings.language.auto') %></option>
+        <% language_names.each do |code, name| %>
+        <option value="<%= code %>"><%= name %></option>
+        <% end %>
+        <option value="disable"><%= I18n.t('presenter.settings.language.disable') %></option>
+      </select>
+      <p class="description">
+        <%= I18n.t('presenter.settings.language.description') %>
+      </p>
+    </div>
+    <% end %>
     <div class="setting">
       <label><%= I18n.t('presenter.settings.layout.label') %></label><br>
       <select id="layoutSelector" autocomplete="off">


### PR DESCRIPTION
If the presentation has multiple translations, this will add a dropdown
in the settings modal for the presenter and the sidebar for the audience
view. The choices are all translations, auto (let the browser choose),
and disabled (always use the original translation).

The UI language is not configurable in this fashion. It always follows
the browser configuration.

Note: translations are incomplete, only the English translations has the new strings.

```
16:15 $ rake lang:check
Error: 'menu.language' is missing from locales/de.yml
Error: 'presenter.settings.language' is missing from locales/de.yml
Error: 'language' is missing from locales/de.yml
Error: 'menu.language' is missing from locales/es.yml
Error: 'presenter.settings.language' is missing from locales/es.yml
Error: 'language' is missing from locales/es.yml
Error: 'menu.language' is missing from locales/fr.yml
Error: 'presenter.settings.language' is missing from locales/fr.yml
Error: 'language' is missing from locales/fr.yml
Error: 'menu.language' is missing from locales/ja.yml
Error: 'presenter.settings.language' is missing from locales/ja.yml
Error: 'language' is missing from locales/ja.yml
Error: 'menu.language' is missing from locales/nl.yml
Error: 'presenter.settings.language' is missing from locales/nl.yml
Error: 'language' is missing from locales/nl.yml
```
