### PR TITLE
Add dialog to choose printed notes type

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1255,8 +1255,9 @@ class ShowOff < Sinatra::Application
       content
     end
 
-    def print(static=false, section=nil)
-      @slides = get_slides_html(:static=>static, :toc=>true, :print=>true, :section=>section)
+    def print(section=nil)
+      section = nil if '' == section
+      @slides = get_slides_html(:static=>true, :toc=>true, :print=>true, :section=>section)
       @favicon = settings.showoff_config['favicon']
       erb :onepage
     end
@@ -1894,7 +1895,7 @@ class ShowOff < Sinatra::Application
 
     begin
       if (what != "favicon.ico")
-        if what == 'supplemental'
+        if ['supplemental', 'print'].include? what
           data = send(what, opt)
         else
           data = send(what)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1256,7 +1256,6 @@ class ShowOff < Sinatra::Application
     end
 
     def print(section=nil)
-      section = nil if '' == section
       @slides = get_slides_html(:static=>true, :toc=>true, :print=>true, :section=>section)
       @favicon = settings.showoff_config['favicon']
       erb :onepage

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -148,6 +148,7 @@ de:
     print:
       label: Wählen Sie die Art der gedruckten Notizen aus
       description: Wählen Sie den Inhalt aus, den Sie unter den Folien anzeigen möchten.
+      none: Notizen nicht enthalten
       notes: Präsentierende Notizen
       handouts: Publikum Handzettel
 

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -145,6 +145,11 @@ de:
         label: Inhalt Sprache
         tooltip: Wählen Sie aus den verfügbaren Übersetzungen aus oder wählen Sie basierend auf Ihren Browsereinstellungen.
         description: Diese Präsentation ist in verschiedenen Sprachen verfügbar. Wählen Sie die Sprache, die Sie anzeigen möchten, oder lassen Sie sie bei <tt>automatisch</tt>, um Ihre Browsereinstellungen zu verwenden.
+    print:
+      label: Wählen Sie die Art der gedruckten Notizen aus
+      description: Wählen Sie den Inhalt aus, den Sie unter den Folien anzeigen möchten.
+      notes: Präsentierende Notizen
+      handouts: Publikum Handzettel
 
   language:
     auto: Automatisch

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -148,6 +148,7 @@ en:
     print:
       label: Choose type of printed notes
       description: Select the content you'd like to show under the slides.
+      none: Don't include notes
       notes: Presenter Notes
       handouts: Audience Handouts
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -145,6 +145,11 @@ en:
         label: Content Language
         tooltip: Select from available translations, or autoselect based on your browser settings.
         description: This presentation is available in different languages. Choose the language you would like to view or leave it at <tt>automatic</tt> to use your browser settings.
+    print:
+      label: Choose type of printed notes
+      description: Select the content you'd like to show under the slides.
+      notes: Presenter Notes
+      handouts: Audience Handouts
 
   language:
     auto: Automatic

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -148,6 +148,7 @@ es:
     print:
       label: Elija el tipo de notas impresas
       description: Selecciona el contenido que quieras mostrar en las diapositivas.
+      none: No incluir notas
       notes: Notas del presentador
       handouts: Folletos de la audiencia
 

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -145,6 +145,11 @@ es:
         label: Idioma del contenido
         tooltip: Seleccione de las traducciones disponibles o autoseleccione en función de la configuración de su navegador.
         description: Esta presentación está disponible en diferentes idiomas. Elija el idioma que desea ver o déjelo en <tt>automático</tt> para usar la configuración de su navegador.
+    print:
+      label: Elija el tipo de notas impresas
+      description: Selecciona el contenido que quieras mostrar en las diapositivas.
+      notes: Notas del presentador
+      handouts: Folletos de la audiencia
 
   language:
     auto: Automático

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -148,6 +148,7 @@ fr:
     print:
       label: Choisir le type de notes imprimées
       description: Sélectionnez le contenu que vous souhaitez afficher sous les diapositives.
+      none: Ne pas inclure de notes
       notes: Notes du présentateur
       handouts: Documents publicitaires
 

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -145,6 +145,11 @@ fr:
         label: Langue de Contenu
         tooltip: Sélectionnez parmi les traductions disponibles, ou autoselect en fonction des paramètres de votre navigateur.
         description: Cette présentation est disponible dans différentes langues. Choisissez la langue que vous souhaitez afficher ou laissez-la à <tt>automatique</tt> pour utiliser les paramètres de votre navigateur.
+    print:
+      label: Choisir le type de notes imprimées
+      description: Sélectionnez le contenu que vous souhaitez afficher sous les diapositives.
+      notes: Notes du présentateur
+      handouts: Documents publicitaires
 
   language:
     auto: Automatique

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -155,6 +155,7 @@ ja:
     print:
       label: Choose type of printed notes
       description: Select the content you'd like to show under the slides.
+      none: Don't include notes
       notes: Presenter Notes
       handouts: Audience Handouts
 

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -152,6 +152,11 @@ ja:
         label: Content Language
         tooltip: Select from available translations, or autoselect based on your browser settings.
         description: This presentation is available in different languages. Choose the language you would like to view or leave it at <tt>automatic</tt> to use your browser settings.
+    print:
+      label: Choose type of printed notes
+      description: Select the content you'd like to show under the slides.
+      notes: Presenter Notes
+      handouts: Audience Handouts
 
   language:
     auto: Automatic

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -145,6 +145,11 @@ nl:
         label: Inhoud Taal
         tooltip: Selecteer uit beschikbare vertalingen of autoselect op basis van uw browserinstellingen.
         description: Deze presentatie is beschikbaar in verschillende talen. Kies de taal die u wilt bekijken of verlaten op <tt>automatisch</tt> om uw browserinstellingen te gebruiken.
+    print:
+      label: Kies het type afgedrukte notities
+      description: Selecteer de inhoud die u onder de dia's wilt weergeven.
+      notes: Aanbieder Opmerkingen
+      handouts: Audience-uitdelingen
 
   language:
     auto: Automatisch

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -148,6 +148,7 @@ nl:
     print:
       label: Kies het type afgedrukte notities
       description: Selecteer de inhoud die u onder de dia's wilt weergeven.
+      none: Voeg geen notities toe
       notes: Aanbieder Opmerkingen
       handouts: Audience-uitdelingen
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -22,7 +22,7 @@ $(document).ready(function(){
 // browser security causes a click event to react differently than an actual user click. Even though they're the same damn thing.
 //  $("#report").click(        function() { reportIssue()   });
   $("#slaveWindow").click(   function() { toggleSlave()   });
-  $("#printSlides").click(   function() { printSlides()   });
+  $("#printSlides").click(   function() { printDialog()   });
   $("#settings").click(      function() { $("#settings-modal").dialog("open"); });
   $("#slideSource a").click( function() { openEditor() });
   $("#notesToggle").click(   function() { toggleNotes() });
@@ -56,7 +56,7 @@ $(document).ready(function(){
   var buttons         = {};
   buttons[closeLabel] = function() { $(this).dialog( "close" ); };
 
-  $("#settings-modal").dialog({
+  $("#settings-modal, #print-modal").dialog({
     autoOpen: false,
     dialogClass: "no-close",
     draggable: false,
@@ -462,15 +462,48 @@ function blankStyledWindow(title, dimensions, classes, resizable) {
   return newWindow;
 }
 
-function printSlides()
+function printDialog() {
+  var list = $('#print-modal #print-sections');
+
+  if(! list.hasClass('processed')) {
+    getAllSections().forEach(function(section) {
+      var link = $('<a>');
+      var item = $('<li>');
+      link.attr('href', '#');
+      link.click(function(){
+        printSlides(section);
+      });
+
+      switch(section) {
+        case 'notes':
+          link.text(I18n.t('presenter.print.notes'));
+          break;
+        case 'handouts':
+          link.text(I18n.t('presenter.print.handouts'));
+          break;
+        default:
+          link.text(section);
+      }
+
+      item.append(link);
+      list.append(item);
+    });
+    list.addClass('processed');
+  }
+
+  $("#print-modal").dialog("open");
+}
+
+function printSlides(section)
 {
   try {
-    var printWindow = window.open('/print');
+    var printWindow = window.open('/print/'+section);
     printWindow.window.print();
   }
   catch(e) {
     console.log('Failed to open print window. Popup blocker?');
   }
+  $("#print-modal").dialog("close");
 }
 
 function postQuestion(question, questionID) {

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -466,7 +466,9 @@ function printDialog() {
   var list = $('#print-modal #print-sections');
 
   if(! list.hasClass('processed')) {
-    getAllSections().forEach(function(section) {
+    sections = getAllSections()
+    sections.unshift('') // add the "none" option
+    sections.forEach(function(section) {
       var link = $('<a>');
       var item = $('<li>');
       link.attr('href', '#');
@@ -475,6 +477,9 @@ function printDialog() {
       });
 
       switch(section) {
+        case '':
+          link.text(I18n.t('presenter.print.none'));
+          break;
         case 'notes':
           link.text(I18n.t('presenter.print.notes'));
           break;

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -737,6 +737,16 @@ function getSlideProgress()
 	return (slidenum + 1) + '/' + slideTotal
 }
 
+function getAllSections()
+{
+  memo = []
+  $("div.notes-section").each(function() {
+    section = $(this).attr('class').split(' ').filter(function(x) { return x != 'notes-section'; })[0];
+    if(! memo.includes(section)) { memo.push(section) }
+  });
+  return memo
+}
+
 function getCurrentSections()
 {
   return currentSlide.find("div.notes-section").map(function() {

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -196,6 +196,11 @@
     </div>
   </div>
 
+  <div id="print-modal" title="<%= I18n.t('presenter.print.label') %>">
+    <p><%= I18n.t('presenter.print.description') %></p>
+    <ul id="print-sections"></ul>
+  </div>
+
   <div id="slides" class="offscreen" <%= 'style="display:none;"' if @slides %>>
   <%= @slides %>
   </div>


### PR DESCRIPTION
Before this, when you clicked the print button, all notes sections would
print -- eg the presenter notes and the audience handouts. This allows
the presenter to choose when they click the button

Fixes #687