### PR TITLE
Make the progress bar go to 9000. (or at least 100%)

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -740,7 +740,7 @@ function postSlide() {
 		var fileName = currentSlide.children('div').first().attr('ref');
 		$('#slideFile').text(fileName);
     $('#progress').progressbar({ max: slideTotal })
-                  .progressbar('value', slidenum);
+                  .progressbar('value', slidenum+1);
 
     $("#notes div.form.wrapper").each(function(e) {
       renderFormInterval = renderFormWatcher($(this));


### PR DESCRIPTION
Unfortunately, in some places, the codebase uses 0-based indexing and
in some it uses 1-based. The slideNum variable is 0-based, but we need
1-based for the progress bar.

Fixes #703