### PR TITLE
Displays correct answer on audience view

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -829,7 +829,7 @@ class ShowOff < Sinatra::Application
     def form_element(id, code, name, required, rhs, text)
       required = required ? 'required' : ''
       str =  "<div class='form element #{required}' id='#{id}' data-name='#{code}'>"
-      str << "<label for='#{id}'>#{name}</label>"
+      str << "<label class='question' for='#{id}'>#{name}</label>"
       case rhs
       when /^\[\s+(\d*)\]$$/             # value = [    5]                                     (textarea)
         str << form_element_textarea(id, code, $1)
@@ -960,10 +960,10 @@ class ShowOff < Sinatra::Application
 
     def form_classes(modifier)
       modifier.downcase!
-      classes = []
+      classes = ['response']
       classes << 'correct' if modifier.include?('=')
 
-      classes.join
+      classes.join(' ')
     end
 
     def form_checked?(modifier)
@@ -1843,7 +1843,7 @@ class ShowOff < Sinatra::Application
               control['id'] = guid()
               EM.next_tick { settings.presenters.each{|s| s.send(control.to_json) } }
 
-            when 'complete'
+            when 'complete', 'answerkey'
               EM.next_tick { settings.sockets.each{|s| s.send(control.to_json) } }
 
             when 'annotation', 'annotationConfig'

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -769,6 +769,36 @@ form .element {
   display: none;
 }
 
+/**********************************
+ ***     form answer key        ***
+ **********************************/
+
+/* no, the option styling will likely not do anything */
+.slide.answerkey form option.incorrect,
+.slide.answerkey form label.incorrect {
+  text-decoration: line-through;
+  font-weight: 100;
+  opacity: .7;
+}
+.slide.answerkey form label.correct,
+.slide.answerkey form option.correct {
+  font-weight: 900;
+}
+/* Be careful with order here; these rules depend on cascading order */
+.slide.answerkey input + option,
+.slide.answerkey input + label.incorrect,
+.slide.answerkey input:checked + label.correct,
+.slide.answerkey input:checked + option.correct {
+  color: #00AA00; /* green */
+}
+.slide.answerkey input:checked + option,
+.slide.answerkey input:checked + label.incorrect,
+.slide.answerkey input + label.correct,
+.slide.answerkey input + option.correct {
+  color: #e74c3c; /* red */
+}
+
+
 /*****************
  ***   modals   ***
  *****************/

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -233,13 +233,17 @@ function initializePresentation(prefix) {
   });
 
   $(".content form div.tools input.display").click(function(e) {
+    var form   = $(this).closest('form');
+    var formID = form.attr('id');
+
+    ws.send(JSON.stringify({ message: 'answerkey', formID: formID}));
     try {
       // If we're a presenter, try to bust open the slave display
-      slaveWindow.renderForm($(this).closest('form').attr('id'));
+      slaveWindow.renderForm(formID);
     }
     catch (e) {
       console.log(e);
-      renderForm($(this).closest('form'));
+      renderForm(form);
     }
   });
 
@@ -870,6 +874,15 @@ function enableForm(element) {
   activityIncomplete = true;
 }
 
+function showFormAnswers(form) {
+  // If we have any correct options, find the parent element, then tag all descendants as incorrect
+  $('.slide.form\\='+form+' label.correct').parents('.form.element').find('label.response,option').addClass('incorrect');
+  // Then remove the double tag from the correct answers.
+  $('.slide.form\\='+form+' label.correct').removeClass('incorrect');
+  // finally, style the slide so we can see the effects
+  $('.slide.form\\='+form).addClass('answerkey')
+}
+
 function renderFormWatcher(element) {
   var form = element.attr('title');
   var action = $('.content form#'+form).attr('action');
@@ -1083,6 +1096,10 @@ function parseMessage(data) {
     switch (command['message']) {
       case 'current':
         follow(command["current"], command["increment"]);
+        break;
+
+      case 'answerkey':
+        showFormAnswers(command["formID"]);
         break;
 
       case 'complete':


### PR DESCRIPTION
When the presenter displays the results, the correct answers are
revealed in the audience view in two ways:

* "correct" options are bolded and "incorrect" ones are struck out.
* If the user answered properly, the option is green, otherwise red.
* If there is no correct alternative, nothing happens.

![screen shot 2017-05-02 at 2 01 02 pm](https://cloud.githubusercontent.com/assets/1392917/25632316/392b231a-2f41-11e7-9c69-6eb665aa0b2d.png)

This isn't the **same** as providing an answer key, but I don't want to
generate *yet another* PDF, so let's roll with this and see how it goes.

Fixes #729