### PR TITLE
added possibility to integrate slide headers and footers

### DIFF
--- a/documentation/AUTHORING.rdoc
+++ b/documentation/AUTHORING.rdoc
@@ -705,6 +705,19 @@ custom layout is to create a container that uses absolute positioning
 and has width and height set to 100% which are then derived from the
 parent slide element.
 
+= Slide Header and Slide Footer
+
+You can also add a header and a footer to slides (outside the
+slide's <tt>div</tt> which wraps its content).
+To do so, specify the Markdown file to use in <tt>showoff.json</tt> using
+the options <tt>slide-header</tt> and <tt>slide-footer</tt>.
+Per default, Showoff will try to load <tt>slide-header.md</tt> and
+<tt>slide-footer.md</tt> from the root of the presentation directory.
+
+The template commands listed above work as well in headers and footers.
+
+An example can be found in the included example directory.
+
 = Live code execution
 
 Showoff can execute code from a slide and display the results live for
@@ -776,4 +789,3 @@ The "add slide" feature can allow you to add the necessary boilerplate from your
   added where your cursor was.  Binding this to a keybinding can allow you to add
   new slides quickly. See the commandline[rdoc-ref:COMMANDLINE] section for
   interesting Showoff commands.
-

--- a/example/slide-footer.md
+++ b/example/slide-footer.md
@@ -1,0 +1,3 @@
+<div class="slide-footer">
+  ~~~CONFIG:author~~~
+</div>

--- a/example/slide-header.md
+++ b/example/slide-header.md
@@ -1,0 +1,3 @@
+<div class="slide-header">
+  ~~~CONFIG:name~~~
+</div>

--- a/example/something.css
+++ b/example/something.css
@@ -4,3 +4,19 @@
 .title-slide h1 {
   color: blue;
 }
+
+.slide-header, .slide-footer {
+  position: absolute;
+  font-size: .5em;
+  width: 100%;
+  text-align: center;
+  color: #888;
+}
+
+.slide-header {
+  top: 0;
+}
+
+.slide-footer {
+  bottom: 0;
+}


### PR DESCRIPTION
This is a quick hack to allow easier integration of slide headers and slide footers.
Example provided.

Without this patch, users are limited to specify headers and footers via templates within `<div class="content …`. When the aforementioned div does not fill the whole height of the presentation, a footer specified within a template does not really look like a footer (but rather like static content floating around in the middle of the screen).

Sadly, I will abandon Showoff for my current purpose, so I probably won't put more effort into this PR, but feel very free to merge this – I'd be happy if it is of any help.

Thanks for this cool project!