### PR TITLE
added missing gem 'rack-contrib' to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ end
 group :test do
   gem 'rake'
 end
+
+gem 'rack-contrib'


### PR DESCRIPTION
When I `bundle install`ed Showoff, I ended up lacking the gem `rack-contrib`.
Therefore, I added this to (all environments in the) Gemfile.

I am not into this whole ruby ecosystem, so please judge the sanity of this PR yourself. :)

Cheers.