### PR TITLE
Add button to sync with the presenter

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -28,6 +28,7 @@ de:
   navigation:
     next: Nächste Folie
     previous: Vorherige Folie
+    sync: Synchronisieren der Präsentation
   loading: laden der Präsentation...
   activity_complete: Aktivität vollständig
   follow:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,6 +28,7 @@ en:
   navigation:
     next: Next
     previous: Previous
+    sync: Sync Presentation
   loading: loading presentation...
   activity_complete: Activity complete
   follow:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -28,6 +28,7 @@ es:
   navigation:
     next: Siguiente
     previous: Anterior
+    sync: Sincronizar presentación
   loading: cargando presentación...
   activity_complete: Actividad completa
   follow:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -28,6 +28,7 @@ fr:
   navigation:
     next: Prochain
     previous: Précédent
+    sync: Synchroniser la présentation
   loading: Chargement de la présentation...
   activity_complete: Activité terminée
   follow:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -28,6 +28,7 @@ ja:
   navigation:
     next: 次へ
     previous: 前へ
+    sync: プレゼンテーションの同期
   loading: プレゼンテーション？ロード中...
   activity_complete: アクティビティ完了
   follow:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -28,6 +28,7 @@ nl:
   navigation:
     next: Volgende
     previous: Vorige
+    sync: Presentatie synchroniseren
   loading: Laden van presentatie...
   activity_complete: Activiteiten voltooid
   follow:

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -28,6 +28,7 @@ pt:
   navigation:
     next: Próximo
     previous: Anterior
+    sync: Sincronizar Apresentação
   loading: carregando apresentação...
   activity_complete: Atividade completada
   follow:

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1199,6 +1199,14 @@ a.term:after {
   right: 1em;
 }
 
+#synchronize {
+  display: none;
+  position: absolute;
+  bottom: 1em;
+  left: 1em;
+  font-size: 0.8em;
+}
+
 /* Render hidden headlines so that when we print with wkhtmltopdf, we can use section
    titles for page headers.  it would make sense to put this in the print section, but
    then you get a weird double headline when previewing a print in the browser. */

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -293,6 +293,10 @@ function openSlave()
       // Add a class to differentiate from the audience view
       slaveWindow.document.getElementById("preso").className = 'display';
 
+      // remove some display view chrome
+      $('.slide.activity', slaveWindow.document).removeClass('activity').children('.activityToggle').remove();
+      $('#synchronize', slaveWindow.document).remove();
+
       // call back and update the parent presenter if the window is closed
       slaveWindow.onunload = function(e) {
         slaveWindow.opener.closeSlave(true);

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -255,10 +255,6 @@ function initializePresentation(prefix) {
     }
   });
 
-  // The display window doesn't need the extra chrome
-  if(typeof(presenterView) != 'undefined') {
-    $('.slide.activity').removeClass('activity').children('.activityToggle').remove();
-  }
   $('.slide.activity .activityToggle input.activity').checkboxradio();
   $('.slide.activity .activityToggle input.activity').change(toggleComplete);
 

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -4,6 +4,7 @@ var ShowOff = {};
 
 var preso_started = false
 var slidenum = 0
+var presenterSlideNum = 0
 var slideTotal = 0
 var slides
 var currentSlide
@@ -115,6 +116,11 @@ function setupPreso(load_slides, prefix) {
     resizable: false,
     width: 640,
     buttons: buttons
+  });
+
+  $("#synchronize").button();
+  $("#synchronize").click(function() {
+    synchronize();
   });
 
   // wait until the presentation is loaded to hook up the previews.
@@ -772,6 +778,9 @@ function showSlide(back_step, updatepv) {
     activityIncomplete = false;
   }
 
+  // show the sync button if we're not on the same slide as the presenter
+  checkSyncState();
+
   // make all bigly text tremendous
   currentSlide.children('.content.bigtext').bigtext();
 
@@ -1278,8 +1287,10 @@ function editSlide() {
   window.open(link);
 }
 
-function follow(slide, newIncrement) {
-  if (mode.follow && ! activityIncomplete) {
+function follow(slide, newIncrement, force) {
+  presenterSlideNum = slide;
+
+  if ((mode.follow && ! activityIncomplete) || force) {
     var lastSlide = slidenum;
     console.log("New slide: " + slide);
     gotoSlide(slide);
@@ -1302,6 +1313,22 @@ function follow(slide, newIncrement) {
 
     }
   }
+
+  // show the sync button if we're not on the same slide as the presenter
+  checkSyncState();
+}
+
+function checkSyncState() {
+  if (presenterSlideNum != slidenum && presenterSlideNum != null) {
+    $("#synchronize").show();
+  }
+  else {
+    $("#synchronize").hide();
+  }
+}
+
+function synchronize() {
+  follow(presenterSlideNum, 0, true);
 }
 
 function getPosition() {

--- a/views/index.erb
+++ b/views/index.erb
@@ -95,7 +95,7 @@
 <%= erb :help %>
 
 <div id="preso"><center><%= I18n.t('loading') %></center></div>
-
+<a id="synchronize"><i class="fa fa-link" aria-hidden="true" href="#"></i> <%= I18n.t('navigation.sync') %></a>
 <div id="notes"></div>
 
 <footer id="footer">


### PR DESCRIPTION
When an audience member navigates to a slide that is not the same as the
one being presented, a button will appear providing a quick shortcut to
jump back to catch up with the presentation. This also appears if the
audience member fails to mark an activity slide complete before the
presenter navigates away from it.

![screen shot 2017-05-28 at 2 06 17 pm](https://cloud.githubusercontent.com/assets/1392917/26532182/e60b35a8-43ae-11e7-9cc6-a59538dbca81.png)
