### PR TITLE
Open Download Files in New Tab or Window

### DIFF
--- a/views/download.erb
+++ b/views/download.erb
@@ -21,7 +21,7 @@
             <% end %>
             <ul>
             <% files.each do |file| %>
-                <li><a href="<%= path %>/<%= file %>"><%= file %></a></li>
+                <li><a href="<%= path %>/<%= file %>" target="_blank"><%= file %></a></li>
             <% end %>
             </ul>
           <% end %>


### PR DESCRIPTION
Added the target attribute to the anchor elements for downloads.
 This will cause them to open in another tab or window, depending
 on the browser settings. Useful because it means that the window
 won't navigate away from the presentation each time you download
 a file.