### PR TITLE
(TRAINTECH-1050) Disconnect Spiking CPU Bug Fix

### DIFF
--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -634,7 +634,9 @@ reconnectControlChannel = function() {
     },
     error: function() {
       console.log("Showoff server unavailable");
-      setTimeout(reconnectControlChannel(), 5000);
+      setTimeout( function() {
+        reconnectControlChannel();
+      }, 5000);
     },
   });
 }


### PR DESCRIPTION
TRAINTECH-1050 #resolved #time 30m
When disconnected from the server, the presenter was causing CPU
 to spike to 100% under certain conditions.  The timeout was not
 set properly and therefore constantly calling every millisecond.
 This fixes the call to only call about every 5 seconds.