### PR TITLE
This allows disjointed slides in the same dir

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -449,6 +449,7 @@ class ShowOffUtils
     # - { "section": [ "array.md, "of.md, "files.md"] }
     # - { "include": "sections.json" }
     sections = {}
+    counters = {}
     lastpath = nil
 
     data.map do |entry|
@@ -492,22 +493,18 @@ class ShowOffUtils
       else
         path = File.dirname(entry)
 
-        # this nastiness just increments a counter in a case like:
-        # "sections": [
-        #   "A/a.md",
-        #   "B/b.md",
-        #   "A/b.md"
-        # ]
-        #
+        # this lastpath business allows us to reference files in a directory that aren't
+        # necessarily contiguous.
         if path != lastpath
-          lastpath = path
-
-          # manipulate path *after* copying it to lastpath
-          count = sections.keys.select {|k| k =~ /^#{path}(-\d+)?$/ }.count
-          path  = "#{path}-#{count}" unless count == 0
-        else
-          lastpath = path
+          counters[path] ||= 0
+          counters[path]  += 1
         end
+
+        # now record the last path we've seen
+        lastpath = path
+
+        # and if there are more than one disparate occurences of path, add a counter to this string
+        path = "#{path} (#{counters[path]})" unless counters[path] == 1
 
         sections[path] ||= []
         sections[path]  << filename

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -449,6 +449,8 @@ class ShowOffUtils
     # - { "section": [ "array.md, "of.md, "files.md"] }
     # - { "include": "sections.json" }
     sections = {}
+    lastpath = nil
+
     data.map do |entry|
       next entry if entry.is_a? String
       next nil unless entry.is_a? Hash
@@ -489,6 +491,24 @@ class ShowOffUtils
         end
       else
         path = File.dirname(entry)
+
+        # this nastiness just increments a counter in a case like:
+        # "sections": [
+        #   "A/a.md",
+        #   "B/b.md",
+        #   "A/b.md"
+        # ]
+        #
+        if path != lastpath
+          lastpath = path
+
+          # manipulate path *after* copying it to lastpath
+          count = sections.keys.select {|k| k =~ /^#{path}(-\d+)?$/ }.count
+          path  = "#{path}-#{count}" unless count == 0
+        else
+          lastpath = path
+        end
+
         sections[path] ||= []
         sections[path]  << filename
       end


### PR DESCRIPTION
e.g.:

    "sections": [
      "A/a.md",
      "B/b.md",
      "A/b.md",
      "B/c.md",
      "A/c.md",
      "A/d.md"
    ]

This allows us to reference files in a directory that aren't necessarily contiguous, as in the example. It just adds a counter each time a directory shows up out of order. 

<img width="278" alt="screen shot 2017-06-06 at 11 07 12 am" src="https://user-images.githubusercontent.com/1392917/26844464-5931ed2e-4aa8-11e7-9e5a-eef07c4c11b4.png">