### PR TITLE
This allows for image paths absolute from the presentation root

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1036,10 +1036,17 @@ class ShowOff < Sinatra::Application
       end
 
       doc.css('img').each do |img|
-        # clean up the path and remove some of the relative nonsense
-        img_path  = Pathname.new(File.join(slide_dir, img[:src])).cleanpath.to_path
+
+        # does the image path start from the preso root?
+        if img[:src].start_with? '/'
+          img_path = img[:src]
+        else
+          # clean up the path and remove some of the relative nonsense
+          img_path = Pathname.new(File.join(slide_dir, img[:src])).cleanpath.to_path
+        end
         src       = "#{replacement_prefix}/#{img_path}"
         img[:src] = src
+
       end
       doc.to_html
     end


### PR DESCRIPTION
If the first character of an image path is `/`, then we now assume that
it's absolute from the presentation root. Otherwise, treat it as
relative and do all the legacy wonkery.