### PR TITLE
Differentiate between menu and questions

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -293,7 +293,7 @@
       min-width: 210px;
       min-height: 210px;
       height: 210px;
-      border-top: 1px solid #ccc;
+      border-top: 3px solid #ccc;
       overflow: auto;
     }
 


### PR DESCRIPTION
With white-on-white-on-white, the questions box was lost in the whiteness.