### PR TITLE
Display info about a presentation

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -68,6 +68,21 @@ module Wrapper
     end
   end
 
+  desc 'Display information about a Showoff presentation'
+  long_desc 'This command compiles the presentation, then lists out all Markdown files, images, stylesheets, and javascripts included.'
+  command [:info] do |c|
+
+    c.desc 'alternate json filename'
+    c.flag [:f,:file]
+
+    c.desc 'render output as json'
+    c.switch [:j,:json]
+
+    c.action do |global_options,options,args|
+      ShowOffUtils.info(options[:f], options[:j])
+    end
+  end
+
   desc 'Validate the consistency of your presentation.'
   long_desc 'This ensures that each file listed in showoff.json exists and validates code blocks on each slide.'
   command [:validate] do |c|

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1258,12 +1258,12 @@ class ShowOff < Sinatra::Application
     end
 
     def slides(static=false)
-      @logger.warn "Cached presentations: #{@@cache.keys}"
+      @logger.info "Cached presentations: #{@@cache.keys}"
 
       # if we have a cache and we're not asking to invalidate it
       return @@cache[@locale] if (@@cache[@locale] and params['cache'] != 'clear')
 
-      @logger.warn "Generating locale: #{@locale}"
+      @logger.info "Generating locale: #{@locale}"
 
       # If we're displaying from a repository, let's update it
       ShowOffUtils.update(settings.verbose) if settings.url


### PR DESCRIPTION
Generates and displays information about a presentation, such as the
markdown files used, images referenced, and all styles/javascripts
included. This makes it easier to see what content is part of a more
complex presentation, with directory globs or composed sections.