### PR TITLE
Allow merged content

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -100,7 +100,7 @@ class ShowOffUtils
   def self.info(config, json = false)
     ShowOffUtils.presentation_config_file = config
     showoff = ShowOff.new!
-    content = showoff.slides
+    content = showoff.slides(false, true)
     dom     = Nokogiri::HTML(content)
 
     data = {}


### PR DESCRIPTION
This means that we just want to generate a *megapresentation* that
represents all content. It's only used for internal methods, such as
`showoff info`, which will use this to generate a list of all images
from the content and all supplemental materials.