### PR TITLE
Explicitly pin the page to the TOP of the viewport

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -8,6 +8,7 @@
           flex-flow: column;
   min-width: 630px;
   min-height: 675px;
+  top: 0; /* this is why we can't have nice things. See #776 */
 }
 
 #timerSection,


### PR DESCRIPTION
Chrome and Firefox on Linux pin this div to the BOTTOM of the viewport
when it's too big. This means that the top of the page scrolls out of
view. Which sucks, since that's where the controls are.

All other browsers, including the same browsers on other platfomr, seem
to pin the div to the TOP, meaning that the bottom scrolls out of
view under the same circumstances.

Fixes #776