### PR TITLE
Make highlighted code readable on dark backgrounds

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -598,6 +598,7 @@ pre.highlight code.language-powershellconsole.nochrome {
 
 pre.highlight code .highlightedLine {
   background-color: #f5e2e2;
+  color: #000;
   display: inline-block;
   width: 100%;
 }


### PR DESCRIPTION
This works even with syntax highlighting because that's done client-side
and will override the stylesheet.

Fixes #781