### PR TITLE
Preshow should ignore files we know aren't images

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -265,7 +265,9 @@ class ShowOff < Sinatra::Application
     end
 
     def preshow_files
-      Dir.glob("#{settings.pres_dir}/_preshow/*").map { |path| File.basename(path) }.to_json
+      files = Dir.glob("#{settings.pres_dir}/_preshow/*")
+      files.reject { |path| ['.txt', '.md'].include? File.extname(path) }
+      files.map { |path| File.basename(path) }.to_json
     end
 
     # return a list of keys associated with a given action in the keymap

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -266,7 +266,7 @@ class ShowOff < Sinatra::Application
 
     def preshow_files
       files = Dir.glob("#{settings.pres_dir}/_preshow/*")
-      files.reject { |path| ['.txt', '.md'].include? File.extname(path) }
+      files.reject! { |path| ['.txt', '.md'].include? File.extname(path) }
       files.map { |path| File.basename(path) }.to_json
     end
 


### PR DESCRIPTION
This allows the author to add a `README.txt` or `.md` to describe what the directory is for.