### PR TITLE
WIP: interstitial loading screen

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -143,7 +143,13 @@
           flex: 5;
   background-color: #fff;
   min-height: 0px;
+  transition: opacity 0.5s ease-in-out;
 }
+
+body.busy #main {
+  opacity: 0;
+}
+
   #sidebar {
     display: -webkit-flex;
     display:         flex;

--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -135,6 +135,7 @@
   }
 
 #main {
+  position: relative;
   display: -webkit-flex;
   display:         flex;
   -webkit-flex-flow: row;
@@ -143,11 +144,6 @@
           flex: 5;
   background-color: #fff;
   min-height: 0px;
-  transition: opacity 0.5s ease-in-out;
-}
-
-body.busy #main {
-  opacity: 0;
 }
 
   #sidebar {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,3 +1,9 @@
+@keyframes spinner {
+  0%   { transform: rotate(0deg)   scale(1.1); color: #ad7586; }
+  50%  { transform: rotate(180deg) scale(0.9); color: #9e6c80; }
+  100% { transform: rotate(359deg) scale(1.1); color: #ad7586; }
+}
+
 body,
 .ui-widget,
 .ui-widget input,
@@ -6,6 +12,25 @@ body,
 .ui-widget button {
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
   color: #222;
+}
+
+/*
+  f110: spinner
+  f1ce: notch
+  f021: refresh
+  f013: gear
+*/
+body:after {
+  content: "\f021";
+  font-family: FontAwesome;
+  position: absolute;
+  font-size: 400px;
+  color: #9f6c8e;
+  top: 65%;
+  left: 50%;
+  margin: -300px 0 0 -200px;
+  z-index: -1;
+  animation: spinner 5s infinite linear;
 }
 
 h1,
@@ -60,6 +85,9 @@ pre code {
     body.busy {
       cursor: progress;
     }
+    body.busy.display #preso {
+      opacity: 0;
+    }
 
   body#download,
   body#stats {
@@ -78,6 +106,7 @@ pre code {
     background-position: center;
     background-size: cover;
     position: relative;
+    transition: opacity 0.5s ease-in-out;
   }
 
   .slide {

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -1,9 +1,3 @@
-@keyframes spinner {
-  0%   { transform: rotate(0deg)   scale(1.1); color: #ad7586; }
-  50%  { transform: rotate(180deg) scale(0.9); color: #9e6c80; }
-  100% { transform: rotate(359deg) scale(1.1); color: #ad7586; }
-}
-
 body,
 .ui-widget,
 .ui-widget input,
@@ -38,7 +32,7 @@ body,
   top: 65%;
   left: 50%;
   margin: -300px 0 0 -200px;
-  animation: spinner 5s infinite linear;
+  animation: fa-spin 5s infinite linear;
 }
 body.busy #interstitial {
   opacity: 1;

--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -20,7 +20,16 @@ body,
   f021: refresh
   f013: gear
 */
-body:after {
+#interstitial {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  background: white;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0.5s ease-out;
+}
+#interstitial #spinner:after {
   content: "\f021";
   font-family: FontAwesome;
   position: absolute;
@@ -29,8 +38,10 @@ body:after {
   top: 65%;
   left: 50%;
   margin: -300px 0 0 -200px;
-  z-index: -1;
   animation: spinner 5s infinite linear;
+}
+body.busy #interstitial {
+  opacity: 1;
 }
 
 h1,
@@ -85,9 +96,6 @@ pre code {
     body.busy {
       cursor: progress;
     }
-    body.busy.display #preso {
-      opacity: 0;
-    }
 
   body#download,
   body#stats {
@@ -106,7 +114,6 @@ pre code {
     background-position: center;
     background-size: cover;
     position: relative;
-    transition: opacity 0.5s ease-in-out;
   }
 
   .slide {

--- a/views/index.erb
+++ b/views/index.erb
@@ -56,6 +56,7 @@
 </head>
 
 <body class="display">
+<div id="interstitial"><div id="spinner"> </div></div>
 <div id="questionsIndicator"></div>
 
 <i id="hamburger" class="fa fa-bars fa-2x"></i>

--- a/views/index.erb
+++ b/views/index.erb
@@ -55,7 +55,7 @@
   </script>
 </head>
 
-<body>
+<body class="display">
 <div id="questionsIndicator"></div>
 
 <i id="hamburger" class="fa fa-bars fa-2x"></i>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -155,6 +155,7 @@
   </div>
 
   <div id="main">
+    <div id="interstitial"><div id="spinner"> </div></div>
     <div id="sidebar">
       <div id="timerSection">
         <input type="button" id="pauseTimer" value="<%= I18n.t('presenter.timer.pause') %>" />


### PR DESCRIPTION
This presents a spinner while the presentation is loading, rather than a
skeleton of a presentation that looks like half of it is just gone.

It's marked at WIP because the animation isn't 100% smooth in all cases.
For example, Chrome chunks a bit when the slides are rendering and
fading in. I will likely redo how the opacity is implemented.

![screen shot 2017-08-31 at 3 50 26 pm](https://user-images.githubusercontent.com/1392917/29948567-68052578-8e64-11e7-8087-278e1c5834c6.png)
