### PR TITLE
Clarify answer key

### DIFF
--- a/public/css/showoff.css
+++ b/public/css/showoff.css
@@ -783,24 +783,33 @@ form .element {
   text-decoration: line-through;
   font-weight: 100;
   opacity: .7;
+  color: #e74c3c; /* red */
 }
 .slide.answerkey form label.correct,
 .slide.answerkey form option.correct {
   font-weight: 900;
-}
-/* Be careful with order here; these rules depend on cascading order */
-.slide.answerkey input + option,
-.slide.answerkey input + label.incorrect,
-.slide.answerkey input:checked + label.correct,
-.slide.answerkey input:checked + option.correct {
   color: #00AA00; /* green */
 }
-.slide.answerkey input:checked + option,
-.slide.answerkey input:checked + label.incorrect,
-.slide.answerkey input + label.correct,
-.slide.answerkey input + option.correct {
-  color: #e74c3c; /* red */
+
+.slide.answerkey input::before {
+  margin-left: -1em;
+  vertical-align: top;
+  font-family: FontAwesome;
+  font-weight: bold;
+  text-decoration: none;
 }
+  /* Be careful with order here; these rules depend on cascading order */
+  .slide.answerkey input::before,
+  .slide.answerkey input.correct:checked::before {
+    content: "\f14a"; /* square checkmark */
+    color: #00AA00;   /* green */
+  }
+  .slide.answerkey input:checked::before,
+  .slide.answerkey input.correct::before {
+    content: "\f00d"; /* times */
+    color: #e74c3c;   /* red */
+  }
+
 
 
 /*****************


### PR DESCRIPTION
The red/green to indicate whether the question had been answered
correctly was confusing. Instead, add a decorator and leave the
color/strikethrough combo to indicate whether an option was correct.

Fixes #795