### PR TITLE
SVG i18n messes up DOM

### DIFF
--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -31,7 +31,7 @@
 
       function translate(item) {
         item = $(item);
-        var text = item.text();
+        var text = item.clone().children().remove().end().text();
 
         if(matches = text.match(/^{{(.*)}}$/) ) {
           keyword = matches[1];

--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -72,7 +72,7 @@
           // nested if because we don't want images to match the final else
           if(item.attr('src').match(/.*\.svg$/i)) {
             inline_svg(item, function(){
-              $(this).find('text, p').each(function(){
+              $(this).find('text, tspan, p').each(function(){
                 translate(this);
               });
             });
@@ -80,7 +80,7 @@
         }
         else if(item.is('svg')) {
           // svg images already inlined. Translate by finding all texty elements
-          item.find('text, p').each(function(){
+          item.find('text, tspan, p').each(function(){
             translate(this);
           });
         }


### PR DESCRIPTION
Here's a simple example:

```svg
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="60" height="20">
  <g transform="translate(10,20)">
    <text><tspan style="fill:#ff0000">{{test}}</tspan></text>
  </g>
</svg>
```

Add a `test` entry in `locales/string.json` with `{ "test": "My test"}`. The text gets replaced, but the style is lost because the `<tspan>` element is removed from the SVG.