### PR TITLE
SVG: translate all {{}} tags in nodes

### DIFF
--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -33,15 +33,14 @@
         item = $(item);
         var text = item.text();
 
-        if(matches = text.match(/{{([^}]*)}}/) ) {
-          $.each(matches, function() {
-              var keyword = this;
-              if(keyword in settings.strings) {
-                  text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
-              }
-          });
-          item.text(text);
+        var re = /{{([^}]+)}}/;
+        while(m = re.exec(text)) {
+          var keyword = m[1];
+          if(keyword in settings.strings) {
+            text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
+          }
         }
+        item.text(text);
 
         return item;
       }

--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -33,12 +33,14 @@
         item = $(item);
         var text = item.text();
 
-        if(matches = text.match(/^{{(.*)}}$/) ) {
-          keyword = matches[1];
-
-          if(keyword in settings.strings) {
-            item.text(settings.strings[keyword]);
-          }
+        if(matches = text.match(/{{([^}]*)}}/) ) {
+          $.each(matches, function() {
+              var keyword = this;
+              if(keyword in settings.strings) {
+                  text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
+              }
+          });
+          item.text(text);
         }
 
         return item;


### PR DESCRIPTION
The current implementation forces to have exactly `^{{some_tag}}$` as
a node text. This patch allows to use multiple tags per node, as well as
additional static text.
