### PR TITLE
Allow smarter links to slides

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -745,6 +745,16 @@ function currentSlideFromName(name) {
   	    found = count;
   	    return false;
   	  }
+      var dataSection = $(slide).attr("data-section").toLowerCase();
+      // firstText is usually a header for the slide
+      var firstText = $(slide).find(".content :first").text().replace(/ /g, '_').toLowerCase();
+      var decodedName = decodeURIComponent(name).toLowerCase();
+      if (decodedName == dataSection+'/'+firstText
+          || name == dataSection
+          || decodedName == firstText  ) {
+        found = count;
+        return false;
+      }
   	  count++;
   	});
 	}

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -747,7 +747,7 @@ function currentSlideFromName(name) {
   	  }
       var dataSection = $(slide).attr("data-section").toLowerCase();
       // firstText is usually a header for the slide
-      var firstText = $(slide).find(".content :first").text().replace(/ /g, '_').toLowerCase();
+      var firstText = $(slide).find(".content :first").text().replace(/[\W]+/g, '-').replace(/-+$/, '').toLowerCase();
       var decodedName = decodeURIComponent(name).toLowerCase();
       if (decodedName == dataSection+'/'+firstText
           || name == dataSection


### PR DESCRIPTION
This allows to make links to slides using the data section and first
text found on the slide (usually the slide title).

For example, for a slide in section "Overview" and with an h2 title of
"Are you ready?", you can use the following links:

  * `#overview/are_you_ready?`
  * `#are_you_ready?`
  * `#overview` (if the slide is the first in the section)