### PR TITLE
translate nodes individually

### DIFF
--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -30,7 +30,9 @@
       }, options );
 
       function interpolate(text) {
-        var tokens = text.split(/{{([^}]+)}}/).filter(Boolean);
+        var tokens  = [];
+        var pattern = /{{([^}]+)}}/g
+        while (item = pattern.exec(text)) { tokens.push(item[1] ) };
 
         tokens.forEach(function(keyword){
           if(keyword in settings.strings) {

--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -29,10 +29,7 @@
         strings: {}
       }, options );
 
-      function translate(item) {
-        item = $(item);
-        var text = item.text();
-
+      function interpolate(text) {
         var re = /{{([^}]+)}}/;
         while(m = re.exec(text)) {
           var keyword = m[1];
@@ -40,9 +37,23 @@
             text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
           }
         }
-        item.text(text);
 
-        return item;
+        return text;
+      }
+
+      function translate(item) {
+        // iterate through nodes contained in this element, including plain text nodes and other elements
+        return $(item).contents()
+          .each(function() {
+            if(this.nodeType == 3) {
+              // translate directly if it's text
+              this.replaceWith(interpolate(this.textContent));
+            }
+            else {
+              // otherwise recurse inside and try again
+              translate(this);
+            }
+          });
       }
 
       function inline_svg(img, callback) {

--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -30,13 +30,13 @@
       }, options );
 
       function interpolate(text) {
-        var re = /{{([^}]+)}}/;
-        while(m = re.exec(text)) {
-          var keyword = m[1];
+        var tokens = text.split(/{{([^}]+)}}/).filter(Boolean);
+
+        tokens.forEach(function(keyword){
           if(keyword in settings.strings) {
             text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
           }
-        }
+        });
 
         return text;
       }


### PR DESCRIPTION
Instead of just doing a simple string replacement, this will identify
text nodes and other DOM nodes contained in an element. It will iterate
each and translate them individually. Text nodes are interpolated
directly, and DOM nodes are recursed on until the text they contain is
interpolated.

Supersedes #848