### PR TITLE
enable dot notation lookup

### DIFF
--- a/public/js/simpleStrings-0.0.1.js
+++ b/public/js/simpleStrings-0.0.1.js
@@ -29,14 +29,22 @@
         strings: {}
       }, options );
 
+      // look up from the translation table using dot notation
+      // returns undefined on miss
+      function lookup(keyword) {
+        return keyword.split('.').reduce(function(obj, key){
+          if(obj != undefined) { return obj[key] }
+        }, settings.strings);
+      }
+
       function interpolate(text) {
         var tokens  = [];
         var pattern = /{{([^}]+)}}/g
         while (item = pattern.exec(text)) { tokens.push(item[1] ) };
 
         tokens.forEach(function(keyword){
-          if(keyword in settings.strings) {
-            text = text.replace('{{'+keyword+'}}', settings.strings[keyword]);
+          if(translation = lookup(keyword)) {
+            text = text.replace('{{'+keyword+'}}', translation);
           }
         });
 


### PR DESCRIPTION
This allows the SimpleStrings library to index deeper into the
translation table using dot notation, just like the built-in UI
translation.

Supersedes #850

Co-authored-by: Raphaël Pinson <raphael.pinson@camptocamp.com>