### PR TITLE
Implement content translation in slides

### DIFF
--- a/documentation/INTERNATIONALIZATION.rdoc
+++ b/documentation/INTERNATIONALIZATION.rdoc
@@ -20,6 +20,9 @@ If you'd like to contribute a translation file, please follow the
 Showoff will present each user with content in the language of their choice.
 It is the author's job to create the translations in the first place.
 
+
+=== Using a language directory
+
 When the presentation is loaded, Showoff matches the language setting of the
 user's browser against the <tt>locales</tt> directory. If it finds a subdirectory
 matching the language, or one of the fallbacks, then that content will be served.
@@ -39,6 +42,25 @@ Images or other media should also be located in the localized directory. This
 allows you to translate any images with text as well. If you don't need this,
 you can symlink the directory, or you can use relative parent paths
 (<tt>../../</tt>) to point to the correct images.
+
+
+=== Using `LANG` tags in content
+
+If you prefer not to duplicate your files in a directory per language, you can
+use LANG tags in the content to mark which content should appear depending on
+the language:
+
+```
+This content will always appear
+
+~~~LANG:en-GB~~~
+This content will only appear in British English
+~~~ENDLANG~~~
+
+~~~LANG:en~~~
+This content will appear for all English localizations
+~~~ENDLANG~~~
+```
 
 == String Replacement
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -506,6 +506,7 @@ class ShowOff < Sinatra::Application
 
         # Apply the template to the slide and replace the key to generate the content of the slide
         sl = process_content_for_replacements(template.gsub(/~~~CONTENT~~~/, slide.text))
+        sl = process_content_for_language(sl, I18n.locale)
         sl = Tilt[:markdown].new(nil, nil, @engine_options) { sl }.render
         sl = build_forms(sl, content_classes)
         sl = update_p_classes(sl)
@@ -533,6 +534,21 @@ class ShowOff < Sinatra::Application
         end
       end
       final
+    end
+
+    def process_content_for_language(content, locale)
+        lang = locale.to_s.split('-').first
+        result = content
+
+        content.scan(/^((~~~LANG:([\w-]+)~~~\n)(.+?)(\n~~~ENDLANG~~~\n))/m).each do |match|
+            if match[2] == lang or match[2] == locale.to_s
+                result.sub!(match[0], match[3])
+            else
+                result.sub!(match[0], '')
+            end
+        end
+
+        result
     end
 
     # This method processes the content of the slide and replaces

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -544,7 +544,7 @@ class ShowOff < Sinatra::Application
             if match[2] == lang or match[2] == locale.to_s
                 result.sub!(match[0], match[3])
             else
-                result.sub!(match[0], '')
+                result.sub!(match[0], "\n")
             end
         end
 


### PR DESCRIPTION
This adds a new `~~~LANG:<lang>~~~` tag allowing to translate content
inside markdown files (as suggested in #843). E.g.:

```
~~~LANG:en~~~
Hello, world!
~~~ENDLANG~~~

~~~LANG:fr~~~
Bonjour tout le monde!
~~~ENDLANG~~~
```