### PR TITLE
Add locales from strings.json to list

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -316,12 +316,22 @@ class ShowOff < Sinatra::Application
 
     # return a hash of all language codes available and the long name description of each
     def language_names
-      Dir.glob('locales/*').inject({}) do |memo, entry|
-        next memo unless File.directory? entry
+      langs = {}
+      Dir.glob('locales/*').each do |entry|
+        next unless File.directory? entry
 
         locale = File.basename(entry)
-        memo.update(locale => get_language_name(locale))
+        langs.update(locale => get_language_name(locale))
       end
+
+      return langs unless File.file? 'locales/strings.json'
+      strings = JSON.parse(File.read('locales/strings.json')) rescue {}
+
+      strings.keys.each do |locale|
+        langs.update(locale => get_language_name(locale))
+      end
+
+      langs
     end
 
     # returns the minimized canonical version of the current selected content locale

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -321,14 +321,14 @@ class ShowOff < Sinatra::Application
         next unless File.directory? entry
 
         locale = File.basename(entry)
-        langs.update(locale => get_language_name(locale))
+        langs[locale] ||= get_language_name(locale)
       end
 
       return langs unless File.file? 'locales/strings.json'
       strings = JSON.parse(File.read('locales/strings.json')) rescue {}
 
       strings.keys.each do |locale|
-        langs.update(locale => get_language_name(locale))
+        langs[locale] ||= get_language_name(locale)
       end
 
       langs


### PR DESCRIPTION
This parses `locales/strings.json` to add languages to the list of available translations.