### PR TITLE
Don't trigger hotkeys when user is typing in fields

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1693,6 +1693,10 @@ function keyDown(event){
   if (event.ctrlKey || event.altKey || event.metaKey) {
     return true;
   }
+  // in case the user is typing in text fields
+  if (document.activeElement.type.substring(0,4) === "text") {
+    return true;
+  }
 
   switch(getAction(event)) {
     case 'DEBUG':     toggleDebug();      break;


### PR DESCRIPTION
I've only been able to trigger this in IE11, but we should avoid it in
any case. I suspect that the underlying problem might also be related to
the javascript load order issue #845.

Fixes #863