### PR TITLE
Use latest commonmarker

### DIFF
--- a/showoff.gemspec
+++ b/showoff.gemspec
@@ -35,8 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency      "sinatra-websocket"
   # workaround a bad dependency in sinatra-websocket
   s.add_dependency      "thin", "~> 1.3"
-  # workaround a semver violation & API breakage in Commonmarker
-  s.add_dependency      "commonmarker", "<= 0.14.4"
+  s.add_dependency      "commonmarker"
 
   s.add_development_dependency "mg"
   s.description       = <<-desc


### PR DESCRIPTION
The APi breakage was "fixed" in tilt as https://github.com/rtomayko/tilt/issues/319, effectively breaking commonmarker support in 0.19.2 and 0.19.3. This fixes it by using the new version of the commonmarker gem again.