### PR TITLE
Map hotkeys for better section navigation

### DIFF
--- a/documentation/CONFIGURATION.rdoc
+++ b/documentation/CONFIGURATION.rdoc
@@ -66,19 +66,27 @@ The actions you may choose from are:
 
 Place a JSON file in <tt>~/.showoff/keymap.json</tt> with any keybindings you'd
 like. You only need to include the keys you want to map, you don't need to
-include all of them.
+include all of them. Note that an UPPERCASED keyword indicates the shifted form
+of that keyword. For example <tt>RIGHT</tt> stands for <tt>shift-right</tt>.
 
 The default mapping is:
 
     {
-      "space"       : "NEXT",
       "d"           : "DEBUG",
-      "up"          : "PREV",
-      "left"        : "PREV",
-      "pageup"      : "PREVSEC",
+      "space"       : "NEXT",
       "down"        : "NEXT",
       "right"       : "NEXT",
-      "pagedown"    : "NEXTSEC",
+      "pagedown"    : "NEXT",
+      "up"          : "PREV",
+      "left"        : "PREV",
+      "pageup"      : "PREV",
+      "SPACE"       : "NEXTSEC",
+      "DOWN"        : "NEXTSEC",
+      "RIGHT"       : "NEXTSEC",
+      "PAGEDOWN"    : "NEXTSEC",
+      "UP"          : "PREVSEC",
+      "LEFT"        : "PREVSEC",
+      "PAGEUP"      : "PREVSEC",
       "r"           : "RELOAD",
       "c"           : "CONTENTS",
       "t"           : "CONTENTS",

--- a/lib/keymap.rb
+++ b/lib/keymap.rb
@@ -1,14 +1,21 @@
 module Keymap
   def self.default()
     {
-      'space'       => 'NEXT',
       'd'           => 'DEBUG',
-      'up'          => 'PREV',
-      'left'        => 'PREV',
-      'pageup'      => 'PREVSEC',
+      'space'       => 'NEXT',
       'down'        => 'NEXT',
       'right'       => 'NEXT',
-      'pagedown'    => 'NEXTSEC',
+      'pagedown'    => 'NEXT',
+      'up'          => 'PREV',
+      'left'        => 'PREV',
+      'pageup'      => 'PREV',
+      'SPACE'       => 'NEXTSEC',
+      'DOWN'        => 'NEXTSEC',
+      'RIGHT'       => 'NEXTSEC',
+      'PAGEDOWN'    => 'NEXTSEC',
+      'UP'          => 'PREVSEC',
+      'LEFT'        => 'PREVSEC',
+      'PAGEUP'      => 'PREVSEC',
       'R'           => 'RELOAD',
       'r'           => 'REFRESH',
       'c'           => 'CONTENTS',
@@ -169,6 +176,13 @@ module Keymap
       "`"           => "~",
       "="           => "+",
       "-"           => "_",
+      "space"       => "SPACE",
+      "down"        => "DOWN",
+      "right"       => "RIGHT",
+      "pagedown"    => "PAGEDOWN",
+      "up"          => "UP",
+      "left"        => "LEFT",
+      "pageup"      => "PAGEUP",
     }
   end
 


### PR DESCRIPTION
This switches back to existing keyboard hotkeys, and allows the shifted
form of each hotkey to navigate to the next/prev section.

Fixes #862