### PR TITLE
Reorder and defer js

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -3,60 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
   <%= erb :header %>
-
-  <script type="text/javascript">
-    // We want the audience members to see automatic tours. We can assume that they won't be
-    // using many server domains like the presenter might.
-    var autoTour = true;
-
-    $( document ).ready(function() {
-      if(presenter && !window.opener) {
-        alert('This is an audience view designed for interactivity. If you are placing this window on a projector, you should use the Display View instead.');
-      }
-
-      tours['showoff:activity'] = [
-        {
-          element: ".currentSlide .activityToggle",
-          intro: I18n.t('tour.activity.complete')
-        }
-      ];
-
-      tours['showoff:form'] = [
-        {
-          element: ".currentSlide input.save",
-          intro: I18n.t('tour.form.save')
-        }
-      ];
-
-      tours['showoff:menu'] = [
-        {
-          element: "#hamburger",
-          intro: I18n.t('tour.menu.start')
-        },
-        {
-          element: "#navToggle",
-          intro: I18n.t('tour.menu.navigation')
-        },
-        {
-          element: "#fileDownloads",
-          intro: I18n.t('tour.menu.download')
-        },
-        {
-          element: "#paceFaster",
-          intro: I18n.t('tour.menu.pace')
-        },
-        {
-          element: "#questionToggle",
-          intro: I18n.t('tour.menu.questions')
-        },
-        {
-          element: "#feedbackToggle",
-          intro: I18n.t('tour.menu.feedback')
-        }
-      ].filter(function(item) { return (document.querySelector(item['element'])) });
-      // display tips for only the enabled features
-    });
-  </script>
 </head>
 
 <body>
@@ -174,6 +120,60 @@
 <div id="pauseScreen">
   <%= @pause_msg %>
 </div>
+
+  <script defer type="text/javascript">
+    // We want the audience members to see automatic tours. We can assume that they won't be
+    // using many server domains like the presenter might.
+    var autoTour = true;
+
+    $( document ).ready(function() {
+      if(presenter && !window.opener) {
+        alert('This is an audience view designed for interactivity. If you are placing this window on a projector, you should use the Display View instead.');
+      }
+
+      tours['showoff:activity'] = [
+        {
+          element: ".currentSlide .activityToggle",
+          intro: I18n.t('tour.activity.complete')
+        }
+      ];
+
+      tours['showoff:form'] = [
+        {
+          element: ".currentSlide input.save",
+          intro: I18n.t('tour.form.save')
+        }
+      ];
+
+      tours['showoff:menu'] = [
+        {
+          element: "#hamburger",
+          intro: I18n.t('tour.menu.start')
+        },
+        {
+          element: "#navToggle",
+          intro: I18n.t('tour.menu.navigation')
+        },
+        {
+          element: "#fileDownloads",
+          intro: I18n.t('tour.menu.download')
+        },
+        {
+          element: "#paceFaster",
+          intro: I18n.t('tour.menu.pace')
+        },
+        {
+          element: "#questionToggle",
+          intro: I18n.t('tour.menu.questions')
+        },
+        {
+          element: "#feedbackToggle",
+          intro: I18n.t('tour.menu.feedback')
+        }
+      ].filter(function(item) { return (document.querySelector(item['element'])) });
+      // display tips for only the enabled features
+    });
+  </script>
 
 </body>
 </html>

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -8,117 +8,6 @@
 
   <script type="text/javascript" src="<%= @asset_path %>/js/TimeCircles-89ac5ae.js"></script>
   <script type="text/javascript" src="<%= @asset_path %>/js/presenter.js?v=<%= SHOWOFF_VERSION %>"></script>
-
-  <script type="text/javascript">
-    editUrl  = "<%= @edit %>";
-    issueUrl = "<%= @issues %>";
-    autoTour = false;
-
-    // increment this each time we add features with new tour stops.
-    tourVersion = 1;
-
-    $(function() {
-      tours['showoff:activity'] = [
-        {
-          element: ".currentSlide .count",
-          intro: I18n.t('tour.activity.count')
-        }
-      ];
-
-      tours['showoff:form'] = [
-        {
-          element: "#notes",
-          intro: I18n.t('tour.form.responses'),
-          scrollToElement: false
-        },
-        {
-          element: ".currentSlide input.display",
-          intro: I18n.t('tour.form.display')
-        }
-      ];
-
-      tours['showoff:presenter'] = [
-        {
-          intro: I18n.t('tour.welcome'),
-          version: 1
-        },
-        {
-          element: "#slaveWindow",
-          intro: I18n.t('tour.displayview'),
-          version: 1
-        },
-        {
-          element: "#annotationLabel",
-          intro: I18n.t('tour.annotations'),
-          version: 1
-        },
-        {
-          element: "#timerSection",
-          intro: I18n.t('tour.timer'),
-          version: 1
-        },
-        {
-          element: "#feedbackPace",
-          intro: I18n.t('tour.pace'),
-          version: 1
-        },
-        {
-          element: "#questions",
-          intro: I18n.t('tour.questions'),
-          version: 1
-        },
-        {
-          element: "#notes-controls",
-          intro: I18n.t('tour.notes'),
-          highlightClass: "tourDark",
-          version: 1
-        },
-        {
-          element: "#slideSource",
-          intro: I18n.t('tour.slidesource'),
-          version: 1
-        },
-        {
-          element: "#settings",
-          intro: I18n.t('tour.settings'),
-          version: 1
-        },
-        {
-          element: "#edit",
-          intro: I18n.t('tour.edit'),
-          version: 1
-        },
-        {
-          element: "#report",
-          intro: I18n.t('tour.report'),
-          version: 1
-        }
-      ].filter(function(item) {
-        // filter out tips for features that have been turned off
-        return ((item['element'] == undefined) || document.querySelector(item['element']));
-      });
-
-      // Only autoshow when served from localhost, since we don't know if we have a consistent domain for our cookie otherwise.
-      if ( location.hostname == 'localhost' || location.hostname == '127.0.0.1' ) {
-
-        // enables the flag that shows feature tours
-        autoTour = true;
-
-        var clientTour = document.cookieHash['tourVersion'] || 0;
-        if(clientTour < tourVersion) {
-          // now make a temporary duplicate of only recent items
-          tours['showoff:presenter:auto'] = tours['showoff:presenter'].filter(function(item) {
-            return (item['version'] > clientTour);
-          });
-
-          // we don't need to let this record, because we've already tested clientTour
-          showTour('showoff:presenter:auto', false);
-        }
-
-      }
-    });
-
-  </script>
 </head>
 
 <body class="presenter">
@@ -311,5 +200,117 @@
   <%= @slides %>
   </div>
 </div><!-- end pagewrapper -->
+
+  <script defer type="text/javascript">
+    editUrl  = "<%= @edit %>";
+    issueUrl = "<%= @issues %>";
+    autoTour = false;
+
+    // increment this each time we add features with new tour stops.
+    tourVersion = 1;
+
+    $(function() {
+      tours['showoff:activity'] = [
+        {
+          element: ".currentSlide .count",
+          intro: I18n.t('tour.activity.count')
+        }
+      ];
+
+      tours['showoff:form'] = [
+        {
+          element: "#notes",
+          intro: I18n.t('tour.form.responses'),
+          scrollToElement: false
+        },
+        {
+          element: ".currentSlide input.display",
+          intro: I18n.t('tour.form.display')
+        }
+      ];
+
+      tours['showoff:presenter'] = [
+        {
+          intro: I18n.t('tour.welcome'),
+          version: 1
+        },
+        {
+          element: "#slaveWindow",
+          intro: I18n.t('tour.displayview'),
+          version: 1
+        },
+        {
+          element: "#annotationLabel",
+          intro: I18n.t('tour.annotations'),
+          version: 1
+        },
+        {
+          element: "#timerSection",
+          intro: I18n.t('tour.timer'),
+          version: 1
+        },
+        {
+          element: "#feedbackPace",
+          intro: I18n.t('tour.pace'),
+          version: 1
+        },
+        {
+          element: "#questions",
+          intro: I18n.t('tour.questions'),
+          version: 1
+        },
+        {
+          element: "#notes-controls",
+          intro: I18n.t('tour.notes'),
+          highlightClass: "tourDark",
+          version: 1
+        },
+        {
+          element: "#slideSource",
+          intro: I18n.t('tour.slidesource'),
+          version: 1
+        },
+        {
+          element: "#settings",
+          intro: I18n.t('tour.settings'),
+          version: 1
+        },
+        {
+          element: "#edit",
+          intro: I18n.t('tour.edit'),
+          version: 1
+        },
+        {
+          element: "#report",
+          intro: I18n.t('tour.report'),
+          version: 1
+        }
+      ].filter(function(item) {
+        // filter out tips for features that have been turned off
+        return ((item['element'] == undefined) || document.querySelector(item['element']));
+      });
+
+      // Only autoshow when served from localhost, since we don't know if we have a consistent domain for our cookie otherwise.
+      if ( location.hostname == 'localhost' || location.hostname == '127.0.0.1' ) {
+
+        // enables the flag that shows feature tours
+        autoTour = true;
+
+        var clientTour = document.cookieHash['tourVersion'] || 0;
+        if(clientTour < tourVersion) {
+          // now make a temporary duplicate of only recent items
+          tours['showoff:presenter:auto'] = tours['showoff:presenter'].filter(function(item) {
+            return (item['version'] > clientTour);
+          });
+
+          // we don't need to let this record, because we've already tested clientTour
+          showTour('showoff:presenter:auto', false);
+        }
+
+      }
+    });
+
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
This places inline js at the end of the page and adds the defer tag.
Thie should (hopefully) ensure that we don't start execution until all
required js libraries are fully evaluated.

Fixes #845