### PR TITLE
Remove asset path again

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -164,9 +164,6 @@ class ShowOff < Sinatra::Application
     @pres_name = settings.pres_dir.split('/').pop
     require_ruby_files
 
-    # Default asset path
-    @asset_path = "./"
-
     # invert the logic to maintain backwards compatibility of interactivity on by default
     @interactive = ! settings.standalone rescue false
 
@@ -836,7 +833,7 @@ class ShowOff < Sinatra::Application
         tools << "<input type=\"button\" class=\"display\" value=\"#{I18n.t('forms.display')}\">"
         tools << "<input type=\"submit\" class=\"save\" value=\"#{I18n.t('forms.save')}\" disabled=\"disabled\">"
         tools << '</div>'
-        form  = "<form id='#{title}' action='/form/#{title}' method='POST'>#{content}#{tools}</form>"
+        form  = "<form id='#{title}' action='form/#{title}' method='POST'>#{content}#{tools}</form>"
         doc = Nokogiri::HTML::DocumentFragment.parse(form)
         doc.css('p').each do |p|
           if p.text =~ /^(\w*) ?(?:->)? ?(.*)? (\*?)= ?(.*)?$/
@@ -1059,11 +1056,11 @@ class ShowOff < Sinatra::Application
 
       case
       when opts[:static] && opts[:pdf]
-        replacement_prefix = "file://#{settings.pres_dir}/"
+        replacement_prefix = "file://#{settings.pres_dir}"
       when opts[:static]
-        replacement_prefix = "./file/"
+        replacement_prefix = './file'
       else
-        replacement_prefix = "#{@asset_path}image/"
+        replacement_prefix = 'image'
       end
 
       doc.css('img').each do |img|
@@ -1214,8 +1211,6 @@ class ShowOff < Sinatra::Application
         @title = ShowOffUtils.showoff_title(settings.pres_dir)
         @slides = get_slides_html(:static=>static)
         @pause_msg = ShowOffUtils.pause_msg
-
-        @asset_path = "./"
       end
 
       # Display favicon in the window if configured
@@ -1945,8 +1940,6 @@ class ShowOff < Sinatra::Application
       locked!
     end
 
-    @asset_path = env['SCRIPT_NAME'] == '' ? nil : env['SCRIPT_NAME'].gsub(/^\/?/, '/').gsub(/\/?$/, '/')
-
     begin
       if (what != "favicon.ico")
         if ['supplemental', 'print'].include? what
@@ -1969,8 +1962,6 @@ class ShowOff < Sinatra::Application
   end
 
   not_found do
-    # Why does the asset path start from cwd??
-    @asset_path.slice!(/^./) rescue nil
     @env = request.env
     erb :'404'
   end

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -43,8 +43,8 @@ $(document).ready(function(){
     notesFontSize('increase');
   });
 
-  $('#statslink').click(function(e) { presenterPopupToggle('/stats', e); });
-  $('#downloadslink').click(function(e) { presenterPopupToggle('/download', e); });
+  $('#statslink').click(function(e) { presenterPopupToggle('stats', e); });
+  $('#downloadslink').click(function(e) { presenterPopupToggle('download', e); });
 
   $('#layoutSelector').change(function(e) { chooseLayout(e.target.value); });
   chooseLayout(null);
@@ -82,7 +82,7 @@ $(document).ready(function(){
 
     $('#topbar #update').click( function(e) {
       e.preventDefault();
-      $.get("/getpage", function(data) {
+      $.get("getpage", function(data) {
         gotoSlide(data);
       });
     });
@@ -154,7 +154,7 @@ $(document).ready(function(){
   setInterval(function() { updatePace() }, 1000);
 
   setInterval(function() {
-    $.getJSON("/stats_data", function( json ) {
+    $.getJSON("stats_data", function( json ) {
       var percent = json['stray_p'];
       if(percent > 25) {
         $('#topbar #statslink').addClass('warning');
@@ -250,7 +250,7 @@ function editSlide() {
 // call the edit endpoint to open up a local file editor
 function openEditor() {
   var slide = $("span#slideFile").text().replace(/:\d+$/, '');
-  var link  = '/edit/' + slide + ".md";
+  var link  = 'edit/' + slide + ".md";
   $.get(link);
 }
 
@@ -277,11 +277,11 @@ function openSlave()
 {
   try {
     if(windowIsClosed(slaveWindow)){
-        slaveWindow = window.open('/' + window.location.hash, 'toolbar');
+        slaveWindow = window.open(window.location.hash, 'toolbar');
     }
     else if(slaveWindow.location.hash != window.location.hash) {
       // maybe we need to reset content?
-      slaveWindow.location.href = '/' + window.location.hash;
+      slaveWindow.location.href = window.location.hash;
     }
 
     // give the window time to load before poking at it
@@ -451,7 +451,7 @@ function blankStyledWindow(title, dimensions, classes, resizable) {
     // them into elements again in the context of the other document.
     // Because IE.
 
-    $(newWindow.document.head).append('<base href="' + window.location.origin + '"/>');
+    $(newWindow.document.head).append('<base href="' + location.origin + location.root + '"/>');
     $('link[rel="stylesheet"]').each(function() {
       var href  = $(this).attr('href');
       var style = '<link rel="stylesheet" type="text/css" href="' + href + '">'
@@ -508,7 +508,7 @@ function printDialog() {
 function printSlides(section)
 {
   try {
-    var printWindow = window.open('/print/'+section);
+    var printWindow = window.open('print/'+section);
     printWindow.window.print();
   }
   catch(e) {

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -277,11 +277,11 @@ function openSlave()
 {
   try {
     if(windowIsClosed(slaveWindow)){
-        slaveWindow = window.open(window.location.hash, 'toolbar');
+        slaveWindow = window.open('./' + window.location.hash, 'toolbar');
     }
     else if(slaveWindow.location.hash != window.location.hash) {
       // maybe we need to reset content?
-      slaveWindow.location.href = window.location.hash;
+      slaveWindow.location.href = './' + window.location.hash;
     }
 
     // give the window time to load before poking at it

--- a/views/download.erb
+++ b/views/download.erb
@@ -14,10 +14,10 @@
           <% enabled, title, files = value %>
           <% if enabled %>
             <%if key != -999 %>
-              <% path = '/file/_files' %>
+              <% path = 'file/_files' %>
               <h4>Slide <%= key %> <small>(<%= title %>)</small></h4>
             <% else %>
-              <% path = '/file/_files/share' %>
+              <% path = 'file/_files/share' %>
             <% end %>
             <ul>
             <% files.each do |file| %>

--- a/views/header.erb
+++ b/views/header.erb
@@ -7,47 +7,47 @@
   <link rel="icon" href="<%= @favicon %>"/>
   <% end %>
 
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/highlight/<%= @highlightStyle %>.css"  />
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/mermaid-6.0.0.css" />
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/font-awesome-4.4.0/css/font-awesome.min.css">
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/introjs-2.5.local.css">
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/jquery-ui-1.12.1.css">
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/zoomline-0.0.1.css">
+  <link rel="stylesheet" type="text/css" href="css/highlight/<%= @highlightStyle %>.css"  />
+  <link rel="stylesheet" type="text/css" href="css/mermaid-6.0.0.css" />
+  <link rel="stylesheet" type="text/css" href="css/font-awesome-4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" type="text/css" href="css/introjs-2.5.local.css">
+  <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.12.1.css">
+  <link rel="stylesheet" type="text/css" href="css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
+  <link rel="stylesheet" type="text/css" href="css/zoomline-0.0.1.css">
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery-2.1.4.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery-ui-1.12.1.js"></script>
+  <script type="text/javascript" src="js/jquery-2.1.4.min.js"></script>
+  <script type="text/javascript" src="js/jquery-ui-1.12.1.js"></script>
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.cycle.all-2.8.0.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.batchImageLoad-1.0.0.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.parsequery.min-6a20f83.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery.doubletap-4ff02c5.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/highlight.pack-9.2.0.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/jTypeWriter-1.1.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/bigtext-0.1.8.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/zoomline-0.0.1.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/simpleStrings-0.0.1.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/mermaid-6.0.0-min.js"></script>
+  <script type="text/javascript" src="js/jquery.cycle.all-2.8.0.js"></script>
+  <script type="text/javascript" src="js/jquery.batchImageLoad-1.0.0.js"></script>
+  <script type="text/javascript" src="js/jquery.parsequery.min-6a20f83.js"></script>
+  <script type="text/javascript" src="js/jquery.doubletap-4ff02c5.js"></script>
+  <script type="text/javascript" src="js/highlight.pack-9.2.0.js"></script>
+  <script type="text/javascript" src="js/jTypeWriter-1.1.js"></script>
+  <script type="text/javascript" src="js/bigtext-0.1.8.js"></script>
+  <script type="text/javascript" src="js/zoomline-0.0.1.js"></script>
+  <script type="text/javascript" src="js/simpleStrings-0.0.1.js"></script>
+  <script type="text/javascript" src="js/mermaid-6.0.0-min.js"></script>
 
   <!-- waiting on https://github.com/usablica/intro.js/pull/727 -->
-  <script type="text/javascript" src="<%= @asset_path %>/js/intro-2.5.local.js"></script>
+  <script type="text/javascript" src="js/intro-2.5.local.js"></script>
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/coffee-script-1.1.3-pre.js"></script>
+  <script type="text/javascript" src="js/coffee-script-1.1.3-pre.js"></script>
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/annotations.js?v=<%= SHOWOFF_VERSION %>"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js?v=<%= SHOWOFF_VERSION %>"></script>
+  <script type="text/javascript" src="js/annotations.js?v=<%= SHOWOFF_VERSION %>"></script>
+  <script type="text/javascript" src="js/showoff.js?v=<%= SHOWOFF_VERSION %>"></script>
 
   <% css_files.each do |css_file| %>
-    <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" type="text/css" href="file/<%= css_file %>" />
   <% end %>
 
   <% js_files.each do |js_file| %>
-    <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
+    <script type="text/javascript" src="file/<%= js_file %>"></script>
   <% end %>
 
   <script type="text/javascript">
     $(function(){
-      setupPreso(<%= @slides.nil? ? "true" : "false"%>, '<%= @asset_path %>');
+      setupPreso(<%= @slides.nil? ? "true" : "false"%>);
     });
 
     editUrl     = "<%= @edit %>";

--- a/views/header_mini.erb
+++ b/views/header_mini.erb
@@ -7,19 +7,19 @@
     <link rel="icon" href="<%= @favicon %>"/>
   <% end %>
 
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/font-awesome-4.4.0/css/font-awesome.min.css">
-  <link rel="stylesheet" type="text/css" href="<%= @asset_path %>/css/zoomline-0.0.1.css">
+  <link rel="stylesheet" type="text/css" href="css/showoff.css?v=<%= SHOWOFF_VERSION %>" />
+  <link rel="stylesheet" type="text/css" href="css/font-awesome-4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" type="text/css" href="css/zoomline-0.0.1.css">
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/jquery-2.1.4.min.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/zoomline-0.0.1.js"></script>
+  <script type="text/javascript" src="js/jquery-2.1.4.min.js"></script>
+  <script type="text/javascript" src="js/zoomline-0.0.1.js"></script>
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/showoff.js?v=<%= SHOWOFF_VERSION %>"></script>
+  <script type="text/javascript" src="js/showoff.js?v=<%= SHOWOFF_VERSION %>"></script>
 
   <% css_files.each do |css_file| %>
-    <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
+    <link rel="stylesheet" type="text/css" href="file/<%= css_file %>" />
   <% end %>
 
   <% js_files.each do |js_file| %>
-    <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
+    <script type="text/javascript" src="file/<%= js_file %>"></script>
   <% end %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -12,7 +12,7 @@
 <div id="sidebarWrapper">
     <div id="navigationHover"></div>
     <div id="feedbackSidebar" class="sideMenu">
-    <img id="disconnected" src="<%= @asset_path %>/css/disconnected.png">
+    <img id="disconnected" src="css/disconnected.png">
     <h3><%= I18n.t('menu.title') %></h3>
     <div id="navToggle" class="buttonWrapper"><i class=" fa fa-bookmark"></i> <%= I18n.t('menu.table_of_contents') %></div>
     <div id="navigation" class="submenu"></div>
@@ -108,7 +108,7 @@
   <span id="debugInfo" class="container"></span>
   <span id="notesInfo" class="container"></span>
   <span id="slideFilename" class="container"></span>
-  <img id="disconnected" src="<%= @asset_path %>/css/disconnected.png" />
+  <img id="disconnected" src="css/disconnected.png" />
 </footer>
 
 <div id="slides" class="offscreen" <%= 'style="display:none;"' if @slides %>>

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -24,23 +24,23 @@
   <% else %>
     <% ['font-awesome-4.4.0/css/font-awesome.min.css', 'mermaid-6.0.0.css', "highlight/#{@highlightStyle}.css",
         'showoff.css', 'onepage.css'].each do |css_file| %>
-      <link rel="stylesheet" href="<%= @asset_path %>/css/<%= css_file %>" type="text/css"/>
+      <link rel="stylesheet" href="css/<%= css_file %>" type="text/css"/>
     <% end %>
 
     <% css_files.each do |css_file| %>
-      <link rel="stylesheet" href="<%= @asset_path %>/file/<%= css_file %>" type="text/css"/>
+      <link rel="stylesheet" href="file/<%= css_file %>" type="text/css"/>
     <% end %>
 
     <% ['jquery-2.1.4.min.js', 'showoff.js', 'highlight.pack-9.2.0.js',
         'bigtext-0.1.8.js', 'simpleStrings-0.0.1.js', 'mermaid-6.0.0-min.js'].each do |js_file| %>
-      <script type="text/javascript" src="<%= @asset_path %>/js/<%= js_file %>"></script>
+      <script type="text/javascript" src="js/<%= js_file %>"></script>
     <% end %>
     <% js_files.each do |js_file| %>
-      <script type="text/javascript" src="<%= @asset_path %>/file/<%= js_file %>"></script>
+      <script type="text/javascript" src="file/<%= js_file %>"></script>
     <% end %>
     <% if @languages %>
       <% @languages.each do |l| %>
-        <script type="text/javascript" src="<%= @asset_path %>/js<%= l %>"></script>
+        <script type="text/javascript" src="js<%= l %>"></script>
       <% end %>
     <% end %>
 

--- a/views/presenter.erb
+++ b/views/presenter.erb
@@ -3,11 +3,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
   <%= erb :header %>
-  <link rel="stylesheet" href="<%= @asset_path %>/css/presenter.css?v=<%= SHOWOFF_VERSION %>" type="text/css"/>
-  <link href="<%= @asset_path %>/css/TimeCircles-89ac5ae.css" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="css/presenter.css?v=<%= SHOWOFF_VERSION %>" />
+  <link rel="stylesheet" type="text/css" href="css/TimeCircles-89ac5ae.css" />
 
-  <script type="text/javascript" src="<%= @asset_path %>/js/TimeCircles-89ac5ae.js"></script>
-  <script type="text/javascript" src="<%= @asset_path %>/js/presenter.js?v=<%= SHOWOFF_VERSION %>"></script>
+  <script type="text/javascript" src="js/TimeCircles-89ac5ae.js"></script>
+  <script type="text/javascript" src="js/presenter.js?v=<%= SHOWOFF_VERSION %>"></script>
 </head>
 
 <body class="presenter">
@@ -63,7 +63,7 @@
         <div class="right obscure"> </div>
         <span id="paceSlow"><%= I18n.t('presenter.pace.faster') %></span>
         <span id="paceFast"><%= I18n.t('presenter.pace.slower') %></span>
-        <img id="paceMarker" src="<%= @asset_path %>/css/paceMarker.png" />
+        <img id="paceMarker" src="css/paceMarker.png" />
       </div>
       <% end %>
 
@@ -83,7 +83,7 @@
     <div id="presenter">
       <div id="frame">
         <div id="preview">
-          <img id="disconnected" src="<%= @asset_path %>/css/disconnected-large.png" />
+          <img id="disconnected" src="css/disconnected-large.png" />
           <div id="prevSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.previous') %></h3></div>
           <div id="nextSlide" class="thumb"><div class="container"></div><h3 class="label"><%= I18n.t('presenter.preview.next') %></h3></div>
           <div id="preso"><%= I18n.t('loading') %></div>


### PR DESCRIPTION
This removes the `asset_path` calculation. It was overcomplicated to begin with, since in almost all cases simply using a relative path worked just as well, and over the years it has caused some errors and prevented us from accomplishing some things.

With this change, we'll soon be able to run showoff behind a proxy, which means that it could be bundled along with Puppetfactory without requiring another port. It also means that multiple presentation could be served from a single machine, routed by the URL path.

It touches a lot of files, but should be relatively 🤞 safe, since Puppet's use of Showoff is currently limited to serving from the `/` path. If I missed any references, they'll show up when we test a non-root path.