### PR TITLE
Get both names for commonmarker support

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -704,7 +704,7 @@ module MarkdownConfig
       when 'kramdown'
         Tilt.prefer Tilt::KramdownTemplate, "markdown"
 
-      when 'commonmarker'
+      when 'commonmarker', 'commonmark'
         Tilt.prefer Tilt::CommonMarkerTemplate, "markdown"
 
       else


### PR DESCRIPTION
Docs weren't clear about what string to to use here in the
`showoff.json`, so let's just get both forms of the name.