### PR TITLE
Set cookie lifetime

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -675,12 +675,12 @@ function showTour(name, record) {
       if(record) {
         clientTours.push(name);
         document.cookieHash['tours'] = clientTours;
-        document.cookie = "tours="+JSON.stringify(clientTours);
+        document.cookie = "tours="+JSON.stringify(clientTours)+"; max-age=31536000; path=/;";
       }
 
       // this keeps track of the version of the presenter tour we've seen
       if(name == 'showoff:presenter:auto') {
-        document.cookie = "tourVersion="+tourVersion;
+        document.cookie = "tourVersion="+tourVersion+"; max-age=31536000; path=/;";
         document.cookieHash['tourVersion'] = tourVersion;
 
         // we don't need this anymore; let's save a byte or three


### PR DESCRIPTION
Without setting the lifetime, the cookie persists for the current
session only. That means that next time you open your browser, you've
got to go through the tour again.

This would not be a problem if we'd fixed #818!