### PR TITLE
Make page printing a bit more robust

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1312,6 +1312,7 @@ class ShowOff < Sinatra::Application
     def print(section=nil)
       @slides = get_slides_html(:static=>true, :toc=>true, :print=>true, :section=>section)
       @favicon = settings.showoff_config['favicon']
+      @printpage = true
       erb :onepage
     end
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -509,7 +509,6 @@ function printSlides(section)
 {
   try {
     var printWindow = window.open('print/'+section);
-    printWindow.window.print();
   }
   catch(e) {
     console.log('Failed to open print window. Popup blocker?');

--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -1847,14 +1847,14 @@ var removeResults = function() {
   try { slaveWindow.removeResults() } catch (e) {};
 };
 
-var print = function(text) {
+var displayHUD = function(text) {
 	removeResults();
 	var _results = $('<div>').addClass('results').html('<pre>' + String(text).substring(0, 1500) + '</pre>');
 	$('body').append(_results);
 	_results.click(removeResults);
 
 	// if we're a presenter, mirror this on the display window
-  try { slaveWindow.print(text) } catch (e) {};
+  try { slaveWindow.displayHUD(text) } catch (e) {};
 };
 
 // Execute the first visible executable code block
@@ -1910,7 +1910,7 @@ function executeLocalCode(lang, codeDiv) {
   catch(e) {
     result = e.message;
   };
-  if (result != null) print(result);
+  if (result != null) displayHUD(result);
 }
 
 // request the server to execute a code block by path and index
@@ -1921,7 +1921,7 @@ function executeRemoteCode(lang, codeDiv) {
 
   setExecutionSignal(true, codeDiv);
   $.get('execute/'+lang, {path: path, index: index}, function(result) {
-    if (result != null) print(result);
+    if (result != null) displayHUD(result);
     setExecutionSignal(false, codeDiv);
   });
 }

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -71,6 +71,10 @@
       $('img').simpleStrings({strings: user_translations});
       $('svg').simpleStrings({strings: user_translations});
       $('.translate').simpleStrings({strings: user_translations});
+
+      <% if @printpage %>
+        window.print();
+      <% end %>
     });
   </script>
 


### PR DESCRIPTION
* Stop overloading window.print() accidentally!
* Remove race condition when trying to print child page
    * instead of calling .print() from the presenter, conditionally
      include it in the child page so it prints once fully rendered.