### PR TITLE
keep the buttons from moving the widget around

### DIFF
--- a/public/css/presenter.css
+++ b/public/css/presenter.css
@@ -192,6 +192,7 @@
     }
     #timerSection #pauseTimer {
       float: left;
+      position: absolute;
       display: none;
     }
     #timerSection #stopTimer {


### PR DESCRIPTION
Fixes #890 

I cannot replicate the timer not canceling. Will reopen if I see the behavior again.