### PR TITLE
More determinate printing

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1312,7 +1312,6 @@ class ShowOff < Sinatra::Application
     def print(section=nil)
       @slides = get_slides_html(:static=>true, :toc=>true, :print=>true, :section=>section)
       @favicon = settings.showoff_config['favicon']
-      @printpage = true
       erb :onepage
     end
 

--- a/public/js/presenter.js
+++ b/public/js/presenter.js
@@ -509,6 +509,9 @@ function printSlides(section)
 {
   try {
     var printWindow = window.open('print/'+section);
+    $(printWindow).on('load', function(){
+      printWindow.window.print();
+    });
   }
   catch(e) {
     console.log('Failed to open print window. Popup blocker?');

--- a/views/onepage.erb
+++ b/views/onepage.erb
@@ -71,10 +71,6 @@
       $('img').simpleStrings({strings: user_translations});
       $('svg').simpleStrings({strings: user_translations});
       $('.translate').simpleStrings({strings: user_translations});
-
-      <% if @printpage %>
-        window.print();
-      <% end %>
     });
   </script>
 


### PR DESCRIPTION
With the js included on the page, then it would print each time you
loaded a statically generated page. Moving it back to presenter.js, but
delayed until loading is complete prints only when intended.