### PR TITLE
Add scripts & styles keys to the presentation file

### DIFF
--- a/documentation/PRESENTATION.rdoc
+++ b/documentation/PRESENTATION.rdoc
@@ -41,6 +41,8 @@ includes all current configuration keys, which will be described below.
       "templates" : {
           "special" : "simple.tpl"
       },
+      "scripts": "assets/animations.js",
+      "styles": "assets/branding.css",
       "pause_msg": "Paused !!!",
       "sections": [
         "Intro/intro.md",
@@ -115,6 +117,11 @@ The configuration settings you may use are listed below. Please see the
   [password]
     The password for protected pages.
 
+[scripts]
+  Showoff will automatically include all javascript files in the root directory
+  of a presentation. This is a list of additional scripts to include afterwards.
+  This can be either a string path or an array of string paths.
+
 [sections]
   The slide definitions for the presentation.
 
@@ -136,6 +143,11 @@ The configuration settings you may use are listed below. Please see the
 
 [standalone]
   If you set this to <tt>true</tt>, then audience interactivity features will be disabled.
+
+[styles]
+  Showoff will automatically include all stylesheets in the root directory of a
+  presentation. This is a list of additional stylesheets to include afterwards.
+  This can be either a string path or an array of string paths.
 
 [templates]
   A hash of templates to be used.

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -254,11 +254,15 @@ class ShowOff < Sinatra::Application
 
   helpers do
     def css_files
-      Dir.glob("#{settings.pres_dir}/*.css").map { |path| File.basename(path) }
+      base  = Dir.glob("#{settings.pres_dir}/*.css").map { |path| File.basename(path) }
+      extra = Array(settings.showoff_config['styles'])
+      base + extra
     end
 
     def js_files
-      Dir.glob("#{settings.pres_dir}/*.js").map { |path| File.basename(path) }
+      base  = Dir.glob("#{settings.pres_dir}/*.js").map { |path| File.basename(path) }
+      extra = Array(settings.showoff_config['scripts'])
+      base + extra
     end
 
     def preshow_files


### PR DESCRIPTION
This allows you to list scripts/styles in a presentation file. It works
well when you've got multiple presentations that should share the same
branding but should also have individual styling per presentation.