### PR TITLE
Add preshow class for specific styling

### DIFF
--- a/public/js/showoff.js
+++ b/public/js/showoff.js
@@ -2002,7 +2002,7 @@ function setupPreShow(seconds) {
           preshow_des = data;
         })
       } else {
-        $('#preshow').append('<img ref="' + n + '" src="file/_preshow/' + n + '"/>');
+        $('#preshow').append('<img ref="' + n + '" src="file/_preshow/' + n + '" class="preshow" />');
       }
     })
     preshow_images      = $('#preshow > img');


### PR DESCRIPTION
Currently, there is no unique selector for images displayed during the preshow. The new `.preshow` class allows you to add specific CSS styles to the preshow images.