### PR TITLE
Avoid `Malformed version number string` errors

### DIFF
--- a/bin/showoff
+++ b/bin/showoff
@@ -212,7 +212,7 @@ module Wrapper
 
       # This is gross. A serious revamp in config file parsing is due.
       config = JSON.parse(File.read(options[:f])) rescue {}
-      if Gem::Version.new(config['version']) > Gem::Version.new(SHOWOFF_VERSION) then
+      if Gem::Version.new(config['version'].to_s) > Gem::Version.new(SHOWOFF_VERSION) then
         raise "This presentation requires Showoff version #{config['version']} or greater."
       end
 


### PR DESCRIPTION
In (some) environments, `showoff serve` on a newly-created skeleton project fails with `error: Malformed version number string`, unless:

* The `version` key is defined in `showoff.json`, or:
* `Gem::Version.new(config['version'])` is modified to avoid passing in a `nil` argument (`.to_s`, `|| 0`, , `|| '0'` all work)

I haven't narrowed down the conditions under which `Gem::Version.new` barfs on `nil`, but sanitizing with `.to_s` ensures that empty config values stay on the safe side.