### PR TITLE
Permit `skeleton -f` file from current directory

### DIFF
--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -68,7 +68,9 @@ class ShowOffUtils
 
   def self.skeleton(config)
     if config
-      FileUtils.cp(config, '.')
+      unless File.expand_path(config) == File.expand_path(File.basename(config),'.')
+        FileUtils.cp(config, '.')
+      end
       ShowOffUtils.presentation_config_file = File.basename(config)
     end
 


### PR DESCRIPTION
Before this change, `bundle exec showoff skeleton --file=file.json` would fail with:

```
error: same file: file.json and ./file.json 
```

This patch skips the `FileUtils.cp` with a naive test to see if the source and destination file are the same file.