### PR TITLE
Fix css/js loading

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1987,6 +1987,8 @@ class Showoff < Sinatra::Application
       if (what != "favicon.ico")
         if ['supplemental', 'print'].include? what
           data = send(what, opt)
+        elsif File.file? what
+          data = File.read(what)
         else
           data = send(what)
         end


### PR DESCRIPTION
This is a bandaid fix to keep the stylesheet/script loading working
properly during the transition to the new architecture. This was
unfortunately broken in #b73463

Fixes #918