### PR TITLE
The better custom css/js loading fix

### DIFF
--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -1988,7 +1988,7 @@ class Showoff < Sinatra::Application
         if ['supplemental', 'print'].include? what
           data = send(what, opt)
         elsif File.file? what
-          data = File.read(what)
+          data = File.open(what)
         else
           data = send(what)
         end


### PR DESCRIPTION
This is the right way to do this, as it lets Sinatra set all the proper
content disposition headers instead of just splatting text back.
Browsers should now load this properly.

Fixes #918 