### PR TITLE
Change CMD to ENTRYPOINT

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,4 +7,4 @@ RUN apk add --no-cache ruby ruby-dev zlib-dev build-base git cmake busybox \
         && rm -rf `gem environment gemdir`/gems/commonmarker-*/test \
         && rm -rf `gem environment gemdir`/cache
 
-CMD ["showoff", "serve"]
+ENTRYPOINT ["showoff", "serve"]


### PR DESCRIPTION
This allows users to specify arguments as params, e.g.:

docker run showoff -f mycourse.json
