### PR TITLE
Allow ! syntax as alternative to ~~~

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,8 +2,9 @@ FROM alpine
 MAINTAINER Ben Ford <ben.ford@puppet.com>
 WORKDIR /var/cache/showoff
 RUN apk add --no-cache ruby ruby-dev zlib-dev build-base git cmake busybox \
-        && gem install etc commonmarker showoff --no-ri --no-rdoc          \
-        && apk del --purge  binutils isl libgomp libatomic mpfr3 mpc1 gcc make musl-dev libc-dev fortify-headers g++ build-base libattr libacl libbz2 xz-libs libarchive cmake \
+        && gem install etc commonmarker showoff specific_install --no-document \
+				&& gem specific_install https://github.com/rtomayko/tilt \
+        && apk del --purge  binutils isl libgomp libatomic mpc1 gcc make musl-dev libc-dev fortify-headers g++ build-base libacl libbz2 xz-libs libarchive cmake \
         && rm -rf `gem environment gemdir`/gems/commonmarker-*/test \
         && rm -rf `gem environment gemdir`/cache
 

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -619,12 +619,12 @@ class Showoff < Sinatra::Application
 
       # because this is post markdown rendering, we may need to shift a <p> tag around
       # remove the tags if they're by themselves
-      result = content.gsub(/<p>~~~SECTION:([^~]*)~~~<\/p>/, '<div class="notes-section \1">')
-      result.gsub!(/<p>~~~ENDSECTION~~~<\/p>/, '</div>')
+      result = content.gsub(/<p>!SECTION:([^!]*)!<\/p>/, '<div class="notes-section \1">')
+      result.gsub!(/<p>!ENDSECTION!<\/p>/, '</div>')
 
       # shove it around the div if it belongs to the contained element
-      result.gsub!(/(<p>)?~~~SECTION:([^~]*)~~~/, '<div class="notes-section \2">\1')
-      result.gsub!(/~~~ENDSECTION~~~(<\/p>)?/, '\1</div>')
+      result.gsub!(/(<p>)?!SECTION:([^!]*)!/, '<div class="notes-section \2">\1')
+      result.gsub!(/!ENDSECTION!(<\/p>)?/, '\1</div>')
 
       # Turn this into a document for munging
       doc = Nokogiri::HTML::DocumentFragment.parse(result)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -624,12 +624,12 @@ class Showoff < Sinatra::Application
       # remove the tags if they're by themselves
       rx_mark = settings.block_rx_mark
       rx_store = settings.block_rx_store
-      result = content.gsub(Regexp.new("<p>#{rx_mark}SECTION:#{rx_store}#{rx_mark}<\/p>"), '<div class="notes-section \1">')
-      result.gsub!(Regexp.new("<p>#{rx_mark}ENDSECTION#{rx_mark}<\/p>"), '</div>')
+      result = content.gsub(/<p>#{rx_mark}SECTION:#{rx_store}#{rx_mark}<\/p>/, '<div class="notes-section \1">')
+      result.gsub!(/<p>#{rx_mark}ENDSECTION#{rx_mark}<\/p>/, '</div>')
 
       # shove it around the div if it belongs to the contained element
-      result.gsub!(Regexp.new("(<p>)?#{rx_mark}SECTION:#{rx_store}#{rx_mark}"), '<div class="notes-section \2">\1')
-      result.gsub!(Regexp.new("#{rx_mark}ENDSECTION#{rx_mark}(<\/p>)?"), '\1</div>')
+      result.gsub!(/(<p>)?#{rx_mark}SECTION:#{rx_store}#{rx_mark}/, '<div class="notes-section \2">\1')
+      result.gsub!(/#{rx_mark}ENDSECTION#{rx_mark}(<\/p>)?/, '\1</div>')
 
       # Turn this into a document for munging
       doc = Nokogiri::HTML::DocumentFragment.parse(result)

--- a/lib/showoff.rb
+++ b/lib/showoff.rb
@@ -59,8 +59,8 @@ class Showoff < Sinatra::Application
   set :encoding, nil
   set :url, nil
 
-  set :block_rx_mark, %r{(~~~|!)}
-  set :block_rx_store, %{([^~!]*)}
+  set :block_rx_mark, %r{(?:~~~|!)}
+  set :block_rx_store, %r{([^~!]*)}
 
   # automatically select the translation based on the user's configured browser language
   use Rack::Locale
@@ -624,12 +624,12 @@ class Showoff < Sinatra::Application
       # remove the tags if they're by themselves
       rx_mark = settings.block_rx_mark
       rx_store = settings.block_rx_store
-      result = content.gsub(/<p>#{rx_mark}SECTION:#{rx_store}#{rx_mark}<\/p>/, '<div class="notes-section \1">')
-      result.gsub!(/<p>#{rx_mark}ENDSECTION#{rx_mark}<\/p>/, '</div>')
+      result = content.gsub(Regexp.new("<p>#{rx_mark}SECTION:#{rx_store}#{rx_mark}<\/p>"), '<div class="notes-section \1">')
+      result.gsub!(Regexp.new("<p>#{rx_mark}ENDSECTION#{rx_mark}<\/p>"), '</div>')
 
       # shove it around the div if it belongs to the contained element
-      result.gsub!(/(<p>)?#{rx_mark}SECTION:#{rx_store}#{rx_mark}/, '<div class="notes-section \2">\1')
-      result.gsub!(/#{rx_mark}ENDSECTION#{rx_mark}(<\/p>)?/, '\1</div>')
+      result.gsub!(Regexp.new("(<p>)?#{rx_mark}SECTION:#{rx_store}#{rx_mark}"), '<div class="notes-section \2">\1')
+      result.gsub!(Regexp.new("#{rx_mark}ENDSECTION#{rx_mark}(<\/p>)?"), '\1</div>')
 
       # Turn this into a document for munging
       doc = Nokogiri::HTML::DocumentFragment.parse(result)


### PR DESCRIPTION
The `~~~` syntax is used by various Markdown parsers as a code block.

This PR allows to use `!` instead, e.g. `!SECTION:notes!` instead of `~~~SECTION:notes~~~`
