### PR TITLE
minor: avoid exit without callbacks

### DIFF
--- a/lib/showoff/compiler.rb
+++ b/lib/showoff/compiler.rb
@@ -67,7 +67,7 @@ class Showoff::Compiler
       end
     rescue LoadError
       puts "ERROR: The #{renderer} markdown rendering engine does not appear to be installed correctly."
-      exit! 1
+      exit 1
     end
 
     profile

--- a/lib/showoff_utils.rb
+++ b/lib/showoff_utils.rb
@@ -173,7 +173,7 @@ class ShowoffUtils
     puts "Found #{errors.size} errors."
     unless errors.empty?
       errors.each { |err| puts " * #{err}" }
-      exit!
+      exit 1
     end
   end
 
@@ -715,7 +715,7 @@ module MarkdownConfig
       end
     rescue LoadError
       puts "ERROR: The #{renderer} markdown rendering engine does not appear to be installed correctly."
-      exit! 1
+      exit 1
     end
   end
 


### PR DESCRIPTION
For cases where the validation of a showoff list returns an error,
calling `exit!` instead of `exit 1` causes output to get lost if
redirected. This could be whilst running in a container, or if
writing to a file.