### PR TITLE
Adding a Dockerfile and updated README with instructions to run using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:3.2.2-alpine
+
+WORKDIR /var/cache/showoff
+
+RUN apk add make gcc musl-dev g++ gcompat && gem install nokogiri showoff
+
+ENTRYPOINT showoff serve

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ you'll need to install both Ruby and the Ruby DevKit for compiling native extens
     gem install showoff
 
 
+Alternatively, you can run Showoff using docker:
+
+    docker run --rm -it -p 9090:9090 -v $(pwd):/var/cache/showoff binford2k/showoff
+
+
+Or build the image yourself:
+
+    docker build -t Dockerfile local/showoff .
+
+
+And run using the locally built image:
+
+    docker run --rm -it -p 9090:9090 -v $(pwd):/var/cache/showoff local/showoff 
+
 ## Documentation
 
 Please see the user manual on the [Showoff homepage](http://puppetlabs.github.io/showoff)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Alternatively, you can run Showoff using docker:
 
 Or build the image yourself:
 
-    docker build -t Dockerfile local/showoff .
+    docker build -t local/showoff .
 
 
 And run using the locally built image:


### PR DESCRIPTION
I experienced the issue described here https://github.com/puppetlabs/showoff/issues/928#issuecomment-846952859 when using the docker image.  It seems the version of Showoff in the docker image is one version behind, from approximately 2 years ago, and it has a bug where images won't render in the presentations.  

I couldn't find the Dockerfile, so I rebuilt it and included it here with instructions to build the image locally.  It would be awesome if we can update the Docker image on Docker Hub, but in the meantime, folks can rebuild the image locally if they want to run with docker.

I checked the examples. From what I can tell, everything works.  I'm new to Showoff, so I wasn't sure what I was supposed to see with the "executable code" slides.  Hope this helps!